### PR TITLE
return default transform for axes in bivariate_matrix api

### DIFF
--- a/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
@@ -1,34 +1,36 @@
-query AxisList($numerator: String, $denominator: String) {
-    getAxes(numerator: $numerator, denominator: $denominator) {axis{
-        label
-        steps {
+query AxisList {
+    getAxes {
+        axis{
             label
-            value
-        }
-        quality
-        quotient
-        quotients {
-            name
-            label
-            emoji
-            description
-            copyrights
-            direction
-            unit {
-                id
-                shortName
-                longName
+            steps {
+                label
+                value
             }
+            quality
+            quotient
+            quotients {
+                name
+                label
+                emoji
+                description
+                copyrights
+                direction
+                unit {
+                    id
+                    shortName
+                    longName
+                }
+            }
+            transformation {
+                transformation
+                min
+                mean
+                stddev
+                lowerBound
+                upperBound
+                skew
+            }
+            parent
         }
-        transformation {
-            transformation
-            min
-            mean
-            stddev
-            lowerBound
-            upperBound
-            skew
-        }
-        parent
-    }}
+    }
 }

--- a/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
@@ -1,0 +1,34 @@
+query AxisList($numerator: String, $denominator: String) {
+    getAxes(numerator: $numerator, denominator: $denominator) {axis{
+        label
+        steps {
+            label
+            value
+        }
+        quality
+        quotient
+        quotients {
+            name
+            label
+            emoji
+            description
+            copyrights
+            direction
+            unit {
+                id
+                shortName
+                longName
+            }
+        }
+        transformation {
+            transformation
+            min
+            mean
+            stddev
+            lowerBound
+            upperBound
+            skew
+        }
+        parent
+    }}
+}

--- a/src/main/graphql/io/kontur/disasterninja/graphql/BivariateMatrix.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/BivariateMatrix.graphql
@@ -25,6 +25,15 @@ query BivariateMatrix($polygon: GeoJSON, $importantLayers: [[String]]) {
                         longName
                     }
                 }
+                transformation {
+                    transformation
+                    min
+                    mean
+                    stddev
+                    lowerBound
+                    upperBound
+                    skew
+                }
                 parent
             }
             meta {

--- a/src/main/graphql/io/kontur/disasterninja/graphql/TransformationList.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/TransformationList.graphql
@@ -1,0 +1,14 @@
+query TransformationList($numerator: String, $denominator: String) {
+    getTransformations(numerator: $numerator, denominator: $denominator) {
+        transformation {
+            transformation
+            min
+            mean
+            stddev
+            lowerBound
+            upperBound
+            skew
+            points
+        }
+    }
+}

--- a/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
@@ -13,6 +13,10 @@ type AxisInfo {
   axis: [Axis]
 }
 
+type TransformationInfo {
+  transformation: [Transformation]
+}
+
 type BivariateStatistic {
   axis: [Axis]
   meta: Meta
@@ -195,7 +199,8 @@ type UrbanCore {
 type Query {
   allStatistic(defaultParam: Int): Statistic
   polygonStatistic(polygonStatisticRequest: PolygonStatisticRequest): PolygonStatistic
-  getAxes(numerator: String, denominator: String): AxisInfo
+  getAxes: AxisInfo
+  getTransformations(numerator: String, denominator: String): TransformationInfo
 }
 
 type Quotient {

--- a/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
@@ -4,6 +4,8 @@ type Axis {
   quality: Float
   quotient: [String]
   quotients: [Quotient]
+  transformation: Transformation
+  transformations: [Transformation]
   parent: [String]
 }
 
@@ -205,6 +207,17 @@ type Unit {
   id: String
   shortName: String
   longName: String
+}
+
+type Transformation {
+    transformation: String
+    min: Float
+    mean: Float
+    skew: Float
+    stddev: Float
+    lowerBound: Float
+    upperBound: Float
+    points: [Float]
 }
 
 schema {

--- a/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
@@ -9,6 +9,10 @@ type Axis {
   parent: [String]
 }
 
+type AxisInfo {
+  axis: [Axis]
+}
+
 type BivariateStatistic {
   axis: [Axis]
   meta: Meta
@@ -191,6 +195,7 @@ type UrbanCore {
 type Query {
   allStatistic(defaultParam: Int): Statistic
   polygonStatistic(polygonStatisticRequest: PolygonStatisticRequest): PolygonStatistic
+  getAxes(numerator: String, denominator: String): AxisInfo
 }
 
 type Quotient {

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClient.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClient.java
@@ -1,5 +1,6 @@
 package io.kontur.disasterninja.client;
 
+import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateMatrixDto;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateStatisticDto;
 import io.kontur.disasterninja.graphql.AdvancedAnalyticalPanelQuery;
@@ -11,6 +12,7 @@ import org.wololo.geojson.GeoJSON;
 import org.wololo.geojson.Geometry;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public interface InsightsApiGraphqlClient {
@@ -22,6 +24,8 @@ public interface InsightsApiGraphqlClient {
 
     CompletableFuture<List<AdvancedAnalyticalPanelQuery.AdvancedAnalytic>> advancedAnalyticsPanelQuery(
             GeoJSON argPolygon, List<AdvancedAnalyticsRequest> argRequest);
+
+    CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList(UUID numerator, UUID denominator);
 
     CompletableFuture<BivariateStatisticDto> getBivariateStatistic();
 

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClient.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClient.java
@@ -1,6 +1,7 @@
 package io.kontur.disasterninja.client;
 
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.domain.Transformation;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateMatrixDto;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateStatisticDto;
 import io.kontur.disasterninja.graphql.AdvancedAnalyticalPanelQuery;
@@ -25,7 +26,9 @@ public interface InsightsApiGraphqlClient {
     CompletableFuture<List<AdvancedAnalyticalPanelQuery.AdvancedAnalytic>> advancedAnalyticsPanelQuery(
             GeoJSON argPolygon, List<AdvancedAnalyticsRequest> argRequest);
 
-    CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList(UUID numerator, UUID denominator);
+    CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList();
+
+    CompletableFuture<List<Transformation>> getTransformationList(UUID numerator, UUID denominator);
 
     CompletableFuture<BivariateStatisticDto> getBivariateStatistic();
 

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClientDummy.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClientDummy.java
@@ -1,6 +1,7 @@
 package io.kontur.disasterninja.client;
 
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.domain.Transformation;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateMatrixDto;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateStatisticDto;
 import io.kontur.disasterninja.graphql.AdvancedAnalyticalPanelQuery;
@@ -33,7 +34,11 @@ public class InsightsApiGraphqlClientDummy implements InsightsApiGraphqlClient {
         return CompletableFuture.completedFuture(Collections.emptyList());
     }
 
-    public CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList(UUID numerator, UUID denominator) {
+    public CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList() {
+        return CompletableFuture.completedFuture(Collections.emptyList());
+    }
+
+    public CompletableFuture<List<Transformation>> getTransformationList(UUID numerator, UUID denominator) {
         return CompletableFuture.completedFuture(Collections.emptyList());
     }
 

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClientDummy.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiGraphqlClientDummy.java
@@ -1,5 +1,6 @@
 package io.kontur.disasterninja.client;
 
+import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateMatrixDto;
 import io.kontur.disasterninja.dto.bivariatematrix.BivariateStatisticDto;
 import io.kontur.disasterninja.graphql.AdvancedAnalyticalPanelQuery;
@@ -13,6 +14,7 @@ import org.wololo.geojson.Geometry;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 public class InsightsApiGraphqlClientDummy implements InsightsApiGraphqlClient {
@@ -28,6 +30,10 @@ public class InsightsApiGraphqlClientDummy implements InsightsApiGraphqlClient {
 
     public CompletableFuture<List<AdvancedAnalyticalPanelQuery.AdvancedAnalytic>> advancedAnalyticsPanelQuery(
             GeoJSON argPolygon, List<AdvancedAnalyticsRequest> argRequest) {
+        return CompletableFuture.completedFuture(Collections.emptyList());
+    }
+
+    public CompletableFuture<List<BivariateLegendAxisDescription>> getAxisList(UUID numerator, UUID denominator) {
         return CompletableFuture.completedFuture(Collections.emptyList());
     }
 

--- a/src/main/java/io/kontur/disasterninja/controller/AxisController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/AxisController.java
@@ -1,0 +1,46 @@
+package io.kontur.disasterninja.controller;
+
+import io.kontur.disasterninja.service.AxisService;
+import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+
+@RestController
+@RequestMapping("/axes")
+@RequiredArgsConstructor
+public class AxisController {
+
+    private final AxisService axisService;
+
+    @Operation(summary = "Get axis information by numerator and denominator UUID", tags = {"Axis"})
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    schema = @Schema(implementation = BivariateLegendAxisDescription.class)))
+    @GetMapping(path = "/{numerator}/{denominator}")
+    public BivariateLegendAxisDescription get(
+            @PathVariable @Parameter(name = "numerator") UUID numerator,
+            @PathVariable @Parameter(name = "denominator") UUID denominator) {
+        List<BivariateLegendAxisDescription> axes = axisService.getDataForAxis(numerator, denominator);
+        return axes.size() > 0 ? axes.get(0) : null;
+    }
+
+    @Operation(summary = "Get axis list", tags = {"Axis"})
+    @ApiResponse(responseCode = "200",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                    array = @ArraySchema(schema = @Schema(implementation = BivariateLegendAxisDescription.class))))
+    @GetMapping
+    public List<BivariateLegendAxisDescription> getList() {
+        return axisService.getDataForAxis(null, null);
+    }
+}

--- a/src/main/java/io/kontur/disasterninja/controller/AxisController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/AxisController.java
@@ -1,7 +1,9 @@
 package io.kontur.disasterninja.controller;
 
-import io.kontur.disasterninja.service.AxisService;
+import io.kontur.disasterninja.controller.exception.WebApplicationException;
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.domain.Transformation;
+import io.kontur.disasterninja.service.AxisService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -9,38 +11,50 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import static java.util.Collections.emptyList;
 
 
 @RestController
-@RequestMapping("/axes")
+@RequestMapping("/axis")
 @RequiredArgsConstructor
 public class AxisController {
 
     private final AxisService axisService;
 
-    @Operation(summary = "Get axis information by numerator and denominator UUID", tags = {"Axis"})
+    @Operation(summary = "Get axis transformations by numerator and denominator UUID", tags = {"Axis"})
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                     schema = @Schema(implementation = BivariateLegendAxisDescription.class)))
-    @GetMapping(path = "/{numerator}/{denominator}")
-    public BivariateLegendAxisDescription get(
+    @ApiResponse(responseCode = "404", description = "Axis is not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+    @GetMapping(path = "/{numerator}/{denominator}/transformations")
+    public ResponseEntity<List<Transformation>> get(
             @PathVariable @Parameter(name = "numerator") UUID numerator,
             @PathVariable @Parameter(name = "denominator") UUID denominator) {
-        List<BivariateLegendAxisDescription> axes = axisService.getDataForAxis(numerator, denominator);
-        return axes.size() > 0 ? axes.get(0) : null;
+        List<Transformation> transformations = axisService.getTransformations(numerator, denominator);
+        if (transformations.size() == 0) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(emptyList());
+        }
+        return ResponseEntity.ok(transformations);
     }
 
     @Operation(summary = "Get axis list", tags = {"Axis"})
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
                     array = @ArraySchema(schema = @Schema(implementation = BivariateLegendAxisDescription.class))))
+    @ApiResponse(responseCode = "204", description = "No content", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @GetMapping
-    public List<BivariateLegendAxisDescription> getList() {
-        return axisService.getDataForAxis(null, null);
+    public ResponseEntity<List<BivariateLegendAxisDescription>> getList() {
+        List<BivariateLegendAxisDescription> axes = axisService.getDataForAxis();
+        if (axes.size() == 0) {
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).body(emptyList());
+        }
+        return ResponseEntity.ok(axes);
     }
 }

--- a/src/main/java/io/kontur/disasterninja/controller/AxisController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/AxisController.java
@@ -31,7 +31,7 @@ public class AxisController {
     @Operation(summary = "Get axis transformations by numerator and denominator UUID", tags = {"Axis"})
     @ApiResponse(responseCode = "200",
             content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
-                    schema = @Schema(implementation = BivariateLegendAxisDescription.class)))
+                    array = @ArraySchema(schema = @Schema(implementation = Transformation.class))))
     @ApiResponse(responseCode = "404", description = "Axis is not found", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
     @GetMapping(path = "/{numerator}/{denominator}/transformations")
     public ResponseEntity<List<Transformation>> get(

--- a/src/main/java/io/kontur/disasterninja/domain/BivariateLegendAxisDescription.java
+++ b/src/main/java/io/kontur/disasterninja/domain/BivariateLegendAxisDescription.java
@@ -25,5 +25,7 @@ public class BivariateLegendAxisDescription {
 
     private List<BivariateLegendQuotient> quotients;
 
+    private Transformation transformation;
+
     private List<String> parent;
 }

--- a/src/main/java/io/kontur/disasterninja/domain/Transformation.java
+++ b/src/main/java/io/kontur/disasterninja/domain/Transformation.java
@@ -1,0 +1,28 @@
+package io.kontur.disasterninja.domain;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@JsonInclude
+public class Transformation {
+
+    private String transformation;
+
+    private Double min;
+
+    private Double mean;
+
+    private Double skew;
+
+    private Double stddev;
+
+    private Double lowerBound;
+
+    private Double upperBound;
+
+    private List<Double> points;
+
+}

--- a/src/main/java/io/kontur/disasterninja/domain/Transformation.java
+++ b/src/main/java/io/kontur/disasterninja/domain/Transformation.java
@@ -6,7 +6,6 @@ import lombok.Data;
 import java.util.List;
 
 @Data
-@JsonInclude
 public class Transformation {
 
     private String transformation;

--- a/src/main/java/io/kontur/disasterninja/domain/Transformation.java
+++ b/src/main/java/io/kontur/disasterninja/domain/Transformation.java
@@ -1,6 +1,5 @@
 package io.kontur.disasterninja.domain;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 
 import java.util.List;

--- a/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
@@ -1,0 +1,67 @@
+package io.kontur.disasterninja.mapper;
+
+import io.kontur.disasterninja.domain.Transformation;
+import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.domain.BivariateLegendAxisStep;
+import io.kontur.disasterninja.domain.BivariateLegendQuotient;
+import io.kontur.disasterninja.domain.Unit;
+import io.kontur.disasterninja.graphql.AxisListQuery;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper
+public interface AxisListMapper {
+
+    AxisListMapper INSTANCE = Mappers.getMapper(AxisListMapper.class);
+
+    @Mapping(target = "transformation", expression = "java(transformation.transformation())")
+    @Mapping(target = "min", expression = "java(transformation.min())")
+    @Mapping(target = "mean", expression = "java(transformation.mean())")
+    @Mapping(target = "skew", expression = "java(transformation.skew())")
+    @Mapping(target = "stddev", expression = "java(transformation.stddev())")
+    @Mapping(target = "lowerBound", expression = "java(transformation.lowerBound())")
+    @Mapping(target = "upperBound", expression = "java(transformation.upperBound())")
+    @Mapping(target = "points", ignore = true)
+    Transformation axisListQueryTransformationToTransformation(AxisListQuery.Transformation transformation);
+
+    @Mapping(target = "id", expression = "java(unit.id())")
+    @Mapping(target = "shortName", expression = "java(unit.shortName())")
+    @Mapping(target = "longName", expression = "java(unit.longName())")
+    Unit axisListQueryUnitToUnit(AxisListQuery.Unit unit);
+
+    List<BivariateLegendAxisDescription> axisListQueryAxisListToBivariateLegendAxisDescriptionList(
+            List<AxisListQuery.Axis> axisListQueryAxisList);
+
+    @Mapping(target = "label", expression = "java(axis.label())")
+    @Mapping(target = "quotient", expression = "java(axis.quotient())")
+    @Mapping(target = "quotients",
+            expression = "java(axisListQueryQuotientListToBivariateLegendQuotientList(axis.quotients()))")
+    @Mapping(target = "steps",
+            expression = "java(axisListQueryStepListToBivariateLegendAxisStepList(axis.steps()))")
+    @Mapping(target = "quality", expression = "java(axis.quality())")
+    @Mapping(target = "transformation", expression = "java(axisListQueryTransformationToTransformation(axis.transformation()))")
+    @Mapping(target = "parent", expression = "java(axis.parent())")
+    BivariateLegendAxisDescription axisListQueryAxisToAxisDescription(AxisListQuery.Axis axis);
+
+    List<BivariateLegendQuotient> axisListQueryQuotientListToBivariateLegendQuotientList(
+            List<AxisListQuery.Quotient> quotients);
+
+    @Mapping(target = "name", expression = "java(quotient.name())")
+    @Mapping(target = "label", expression = "java(quotient.label())")
+    @Mapping(target = "emoji", expression = "java(quotient.emoji())")
+    @Mapping(target = "description", expression = "java(quotient.description())")
+    @Mapping(target = "copyrights", expression = "java(quotient.copyrights())")
+    @Mapping(target = "direction", expression = "java(quotient.direction())")
+    @Mapping(target = "unit", expression = "java(axisListQueryUnitToUnit(quotient.unit()))")
+    BivariateLegendQuotient axisListQueryQuotientToBivariateLegendQuotient(AxisListQuery.Quotient quotient);
+
+    @Mapping(target = "value", expression = "java(step.value())")
+    @Mapping(target = "label", expression = "java(step.label())")
+    BivariateLegendAxisStep axisListQueryStepToBivariateLegendAxisStep(AxisListQuery.Step step);
+
+    List<BivariateLegendAxisStep> axisListQueryStepListToBivariateLegendAxisStepList(
+            List<AxisListQuery.Step> steps);
+}

--- a/src/main/java/io/kontur/disasterninja/mapper/BivariateStatisticMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/BivariateStatisticMapper.java
@@ -1,5 +1,6 @@
 package io.kontur.disasterninja.mapper;
 
+import io.kontur.disasterninja.domain.Transformation;
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
 import io.kontur.disasterninja.domain.BivariateLegendAxisStep;
 import io.kontur.disasterninja.domain.BivariateLegendQuotient;
@@ -41,6 +42,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateLayerLegendQueryStepListToBivariateLegendAxisStepList(x.steps()))")
     @Mapping(target = "quality", ignore = true)
+    @Mapping(target = "transformation", ignore = true)
     @Mapping(target = "parent", ignore = true)
     BivariateLegendAxisDescription bivariateLayerLegendQueryXAxisToAxisDescription(BivariateLayerLegendQuery.X x);
 
@@ -69,6 +71,16 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "longName", expression = "java(unit.longName())")
     Unit bivariateLayerLegendQueryUnitToUnit(BivariateLayerLegendQuery.Unit unit);
 
+    @Mapping(target = "transformation", expression = "java(transformation.transformation())")
+    @Mapping(target = "min", expression = "java(transformation.min())")
+    @Mapping(target = "mean", expression = "java(transformation.mean())")
+    @Mapping(target = "skew", expression = "java(transformation.skew())")
+    @Mapping(target = "stddev", expression = "java(transformation.stddev())")
+    @Mapping(target = "lowerBound", expression = "java(transformation.lowerBound())")
+    @Mapping(target = "upperBound", expression = "java(transformation.upperBound())")
+    @Mapping(target = "points", ignore = true)
+    Transformation bivariateMatrixQueryTransformationToTransformation(BivariateMatrixQuery.Transformation transformation);
+
     @Mapping(target = "label", expression = "java(y.label())")
     @Mapping(target = "quotient", expression = "java(y.quotient())")
     @Mapping(target = "quotients",
@@ -76,6 +88,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateLayerLegendQueryStep1ListToBivariateLegendAxisStepList(y.steps()))")
     @Mapping(target = "quality", ignore = true)
+    @Mapping(target = "transformation", ignore = true)
     @Mapping(target = "parent", ignore = true)
     BivariateLegendAxisDescription bivariateLayerLegendQueryYAxisToAxisDescription(BivariateLayerLegendQuery.Y y);
 
@@ -152,6 +165,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateMatrixQueryStepListToBivariateLegendAxisStepList(axis.steps()))")
     @Mapping(target = "quality", expression = "java(axis.quality())")
+    @Mapping(target = "transformation", expression = "java(bivariateMatrixQueryTransformationToTransformation(axis.transformation()))")
     @Mapping(target = "parent", expression = "java(axis.parent())")
     BivariateLegendAxisDescription bivariateMatrixQueryAxisToAxisDescription(BivariateMatrixQuery.Axis axis);
 
@@ -201,6 +215,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateMatrixQueryStep1ListToBivariateLegendAxisStepList(x.steps()))")
     @Mapping(target = "quality", expression = "java(x.quality())")
+    @Mapping(target = "transformation", ignore = true)
     @Mapping(target = "parent", expression = "java(x.parent())")
     @Mapping(target = "quotients", ignore = true)
     BivariateLegendAxisDescription bivariateMatrixQueryXAxisToAxisDescription(BivariateMatrixQuery.X x);
@@ -217,6 +232,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateMatrixQueryStep2ListToBivariateLegendAxisStepList(y.steps()))")
     @Mapping(target = "quality", expression = "java(y.quality())")
+    @Mapping(target = "transformation", ignore = true)
     @Mapping(target = "parent", expression = "java(y.parent())")
     @Mapping(target = "quotients", ignore = true)
     BivariateLegendAxisDescription bivariateMatrixQueryYAxisToAxisDescription(BivariateMatrixQuery.Y y);

--- a/src/main/java/io/kontur/disasterninja/mapper/TransformationListMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/TransformationListMapper.java
@@ -1,0 +1,29 @@
+package io.kontur.disasterninja.mapper;
+
+import io.kontur.disasterninja.domain.Transformation;
+import io.kontur.disasterninja.graphql.TransformationListQuery;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper
+public interface TransformationListMapper {
+
+    TransformationListMapper INSTANCE = Mappers.getMapper(TransformationListMapper.class);
+
+    @Mapping(target = "transformation", expression = "java(transformation.transformation())")
+    @Mapping(target = "min", expression = "java(transformation.min())")
+    @Mapping(target = "mean", expression = "java(transformation.mean())")
+    @Mapping(target = "skew", expression = "java(transformation.skew())")
+    @Mapping(target = "stddev", expression = "java(transformation.stddev())")
+    @Mapping(target = "lowerBound", expression = "java(transformation.lowerBound())")
+    @Mapping(target = "upperBound", expression = "java(transformation.upperBound())")
+    @Mapping(target = "points", expression = "java(transformation.points())")
+    Transformation transformationListQueryTransformationToTransformation(TransformationListQuery.Transformation transformation);
+
+    List<Transformation> transformationListQueryTransformationListToTransformationList(
+            List<TransformationListQuery.Transformation> transformationListQueryTransformationList);
+
+}

--- a/src/main/java/io/kontur/disasterninja/service/AxisService.java
+++ b/src/main/java/io/kontur/disasterninja/service/AxisService.java
@@ -1,0 +1,31 @@
+package io.kontur.disasterninja.service;
+
+import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.client.InsightsApiGraphqlClient;
+import io.kontur.disasterninja.controller.exception.WebApplicationException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AxisService {
+    private static final Logger LOG = LoggerFactory.getLogger(AxisService.class);
+
+    private final InsightsApiGraphqlClient insightsApiGraphqlClient;
+
+        public List<BivariateLegendAxisDescription> getDataForAxis(UUID numerator, UUID denominator) {
+        try {
+            return insightsApiGraphqlClient.getAxisList(numerator, denominator).get();
+        } catch (Exception e) {
+            LOG.error("Can't load axis due to exception in graphql call: {}", e.getMessage(), e);
+            throw new WebApplicationException("Exception when getting data from insights-api using apollo client",
+                    HttpStatus.BAD_GATEWAY);
+        }
+    }
+}

--- a/src/main/java/io/kontur/disasterninja/service/AxisService.java
+++ b/src/main/java/io/kontur/disasterninja/service/AxisService.java
@@ -1,6 +1,7 @@
 package io.kontur.disasterninja.service;
 
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
+import io.kontur.disasterninja.domain.Transformation;
 import io.kontur.disasterninja.client.InsightsApiGraphqlClient;
 import io.kontur.disasterninja.controller.exception.WebApplicationException;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +20,19 @@ public class AxisService {
 
     private final InsightsApiGraphqlClient insightsApiGraphqlClient;
 
-        public List<BivariateLegendAxisDescription> getDataForAxis(UUID numerator, UUID denominator) {
+    public List<Transformation> getTransformations(UUID numerator, UUID denominator) {
         try {
-            return insightsApiGraphqlClient.getAxisList(numerator, denominator).get();
+            return insightsApiGraphqlClient.getTransformationList(numerator, denominator).get();
+        } catch (Exception e) {
+            LOG.error("Can't load transformations due to exception in graphql call: {}", e.getMessage(), e);
+            throw new WebApplicationException("Exception when getting data from insights-api using apollo client",
+                    HttpStatus.BAD_GATEWAY);
+        }
+    }
+
+    public List<BivariateLegendAxisDescription> getDataForAxis() {
+        try {
+            return insightsApiGraphqlClient.getAxisList().get();
         } catch (Exception e) {
             LOG.error("Can't load axis due to exception in graphql call: {}", e.getMessage(), e);
             throw new WebApplicationException("Exception when getting data from insights-api using apollo client",

--- a/src/test/java/io/kontur/disasterninja/util/TestUtil.java
+++ b/src/test/java/io/kontur/disasterninja/util/TestUtil.java
@@ -27,9 +27,9 @@ public final class TestUtil {
 
         BivariateLegendAxes axes = new BivariateLegendAxes();
         axes.setX(new BivariateLegendAxisDescription("xLabel", null, null, null,
-                null, null));
+                null, null, null));
         axes.setY(new BivariateLegendAxisDescription("yLabel", null, null, null,
-                null, null));
+                null, null, null));
 
         Legend legend = new Legend("legendName", LegendType.SIMPLE, null, new ArrayList<>(),
                 Collections.singletonList(new ColorDto("A1", "rgb(232,232,157)")), axes,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new REST endpoint to retrieve axis information based on UUIDs.
  - Added a new GraphQL query to fetch axis data with transformation details.
  - Enhanced the BivariateMatrix query to include various statistical transformation properties.

- **Enhancements**
  - Added support for detailed statistical transformations in several queries and services.
  - Introduced a new `Transformation` data class to encapsulate statistical properties.

- **Configuration**
  - Updated `insightsApi` URL in the configuration file to point to a localhost endpoint for development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->