### PR TITLE
18786 layers endpoint should not return nulls

### DIFF
--- a/src/main/java/io/kontur/disasterninja/controller/AppsController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/AppsController.java
@@ -114,7 +114,12 @@ public class AppsController {
         while (iterator.hasNext()) {
             Layer next = iterator.next();
             if (bivariateLayerProvider.isApplicable(next.getId())) {
-                iterator.set(bivariateLayerProvider.obtainLayer(next.getId(), null));
+                Layer obtainedLayer = bivariateLayerProvider.obtainLayer(next.getId(), null);
+                if (obtainedLayer != null) {
+                    iterator.set(obtainedLayer);
+                } else {
+                    iterator.remove();
+                }
             }
         }
 

--- a/src/main/java/io/kontur/disasterninja/service/layers/providers/BivariateLayerProvider.java
+++ b/src/main/java/io/kontur/disasterninja/service/layers/providers/BivariateLayerProvider.java
@@ -99,6 +99,9 @@ public class BivariateLayerProvider implements LayerProvider {
             return null;
         }
         reloadLayersIfEmpty();
+        if (!bivariateLayers.containsKey(layerId)) {
+            reloadLayers();
+        }
         return bivariateLayers.get(layerId);
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved layer retrieval to handle cases where the obtained layer is null by removing it from the list.
  - Added logic to reload layers if a specific layer ID is not found, ensuring more robust layer fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->