### PR TITLE
add DatasetStats object to Axis

### DIFF
--- a/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
@@ -6,6 +6,12 @@ query AxisList {
                 label
                 value
             }
+            datasetStats{
+                minValue,
+                maxValue,
+                meanValue,
+                stddevValue
+            }
             quality
             quotient
             quotients {

--- a/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/AxisList.graphql
@@ -9,8 +9,8 @@ query AxisList {
             datasetStats{
                 minValue,
                 maxValue,
-                meanValue,
-                stddevValue
+                mean,
+                stddev
             }
             quality
             quotient

--- a/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
@@ -1,6 +1,7 @@
 type Axis {
   label: String
   steps: [Step]
+  datasetStats: DatasetStats
   quality: Float
   quotient: [String]
   quotients: [Quotient]
@@ -228,6 +229,13 @@ type Transformation {
     lowerBound: Float
     upperBound: Float
     points: [Float]
+}
+
+type DatasetStats {
+    minValue: Float
+    maxValue: Float
+    meanValue: Float
+    stddevValue: Float
 }
 
 schema {

--- a/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
+++ b/src/main/graphql/io/kontur/disasterninja/graphql/schema.graphqls
@@ -234,8 +234,8 @@ type Transformation {
 type DatasetStats {
     minValue: Float
     maxValue: Float
-    meanValue: Float
-    stddevValue: Float
+    mean: Float
+    stddev: Float
 }
 
 schema {

--- a/src/main/java/io/kontur/disasterninja/domain/BivariateLegendAxisDescription.java
+++ b/src/main/java/io/kontur/disasterninja/domain/BivariateLegendAxisDescription.java
@@ -19,6 +19,8 @@ public class BivariateLegendAxisDescription {
 
     private List<BivariateLegendAxisStep> steps;
 
+    private DatasetStats datasetStats;
+
     private Double quality;
 
     private List<String> quotient;

--- a/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
+++ b/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
@@ -1,0 +1,18 @@
+package io.kontur.disasterninja.domain;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class DatasetStats {
+
+    private Double minValue;
+
+    private Double maxValue;
+
+    private Double meanValue;
+
+    private Double stddevValue;
+
+}

--- a/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
+++ b/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
@@ -2,8 +2,6 @@ package io.kontur.disasterninja.domain;
 
 import lombok.Data;
 
-import java.util.List;
-
 @Data
 public class DatasetStats {
 

--- a/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
+++ b/src/main/java/io/kontur/disasterninja/domain/DatasetStats.java
@@ -11,8 +11,8 @@ public class DatasetStats {
 
     private Double maxValue;
 
-    private Double meanValue;
+    private Double mean;
 
-    private Double stddevValue;
+    private Double stddev;
 
 }

--- a/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
@@ -29,7 +29,7 @@ public interface AxisListMapper {
     Transformation axisListQueryTransformationToTransformation(AxisListQuery.Transformation transformation);
 
     @Mapping(target = "minValue", expression = "java(datasetStats.minValue())")
-    @Mapping(target = "maxValue", expression = "java(datasetStats.minValue())")
+    @Mapping(target = "maxValue", expression = "java(datasetStats.maxValue())")
     @Mapping(target = "mean", expression = "java(datasetStats.mean())")
     @Mapping(target = "stddev", expression = "java(datasetStats.stddev())")
     DatasetStats axisListQueryDatasetStatsToDatasetStats(AxisListQuery.DatasetStats datasetStats);

--- a/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
@@ -30,8 +30,8 @@ public interface AxisListMapper {
 
     @Mapping(target = "minValue", expression = "java(datasetStats.minValue())")
     @Mapping(target = "maxValue", expression = "java(datasetStats.minValue())")
-    @Mapping(target = "meanValue", expression = "java(datasetStats.meanValue())")
-    @Mapping(target = "stddevValue", expression = "java(datasetStats.stddevValue())")
+    @Mapping(target = "mean", expression = "java(datasetStats.mean())")
+    @Mapping(target = "stddev", expression = "java(datasetStats.stddev())")
     DatasetStats axisListQueryDatasetStatsToDatasetStats(AxisListQuery.DatasetStats datasetStats);
 
     @Mapping(target = "id", expression = "java(unit.id())")

--- a/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/AxisListMapper.java
@@ -1,6 +1,7 @@
 package io.kontur.disasterninja.mapper;
 
 import io.kontur.disasterninja.domain.Transformation;
+import io.kontur.disasterninja.domain.DatasetStats;
 import io.kontur.disasterninja.domain.BivariateLegendAxisDescription;
 import io.kontur.disasterninja.domain.BivariateLegendAxisStep;
 import io.kontur.disasterninja.domain.BivariateLegendQuotient;
@@ -27,6 +28,12 @@ public interface AxisListMapper {
     @Mapping(target = "points", ignore = true)
     Transformation axisListQueryTransformationToTransformation(AxisListQuery.Transformation transformation);
 
+    @Mapping(target = "minValue", expression = "java(datasetStats.minValue())")
+    @Mapping(target = "maxValue", expression = "java(datasetStats.minValue())")
+    @Mapping(target = "meanValue", expression = "java(datasetStats.meanValue())")
+    @Mapping(target = "stddevValue", expression = "java(datasetStats.stddevValue())")
+    DatasetStats axisListQueryDatasetStatsToDatasetStats(AxisListQuery.DatasetStats datasetStats);
+
     @Mapping(target = "id", expression = "java(unit.id())")
     @Mapping(target = "shortName", expression = "java(unit.shortName())")
     @Mapping(target = "longName", expression = "java(unit.longName())")
@@ -43,6 +50,7 @@ public interface AxisListMapper {
             expression = "java(axisListQueryStepListToBivariateLegendAxisStepList(axis.steps()))")
     @Mapping(target = "quality", expression = "java(axis.quality())")
     @Mapping(target = "transformation", expression = "java(axisListQueryTransformationToTransformation(axis.transformation()))")
+    @Mapping(target = "datasetStats", expression = "java(axisListQueryDatasetStatsToDatasetStats(axis.datasetStats()))")
     @Mapping(target = "parent", expression = "java(axis.parent())")
     BivariateLegendAxisDescription axisListQueryAxisToAxisDescription(AxisListQuery.Axis axis);
 

--- a/src/main/java/io/kontur/disasterninja/mapper/BivariateStatisticMapper.java
+++ b/src/main/java/io/kontur/disasterninja/mapper/BivariateStatisticMapper.java
@@ -43,6 +43,7 @@ public interface BivariateStatisticMapper {
             expression = "java(bivariateLayerLegendQueryStepListToBivariateLegendAxisStepList(x.steps()))")
     @Mapping(target = "quality", ignore = true)
     @Mapping(target = "transformation", ignore = true)
+    @Mapping(target = "datasetStats", ignore = true)
     @Mapping(target = "parent", ignore = true)
     BivariateLegendAxisDescription bivariateLayerLegendQueryXAxisToAxisDescription(BivariateLayerLegendQuery.X x);
 
@@ -89,6 +90,7 @@ public interface BivariateStatisticMapper {
             expression = "java(bivariateLayerLegendQueryStep1ListToBivariateLegendAxisStepList(y.steps()))")
     @Mapping(target = "quality", ignore = true)
     @Mapping(target = "transformation", ignore = true)
+    @Mapping(target = "datasetStats", ignore = true)
     @Mapping(target = "parent", ignore = true)
     BivariateLegendAxisDescription bivariateLayerLegendQueryYAxisToAxisDescription(BivariateLayerLegendQuery.Y y);
 
@@ -165,6 +167,7 @@ public interface BivariateStatisticMapper {
     @Mapping(target = "steps",
             expression = "java(bivariateMatrixQueryStepListToBivariateLegendAxisStepList(axis.steps()))")
     @Mapping(target = "quality", expression = "java(axis.quality())")
+    @Mapping(target = "datasetStats", ignore = true)
     @Mapping(target = "transformation", expression = "java(bivariateMatrixQueryTransformationToTransformation(axis.transformation()))")
     @Mapping(target = "parent", expression = "java(axis.parent())")
     BivariateLegendAxisDescription bivariateMatrixQueryAxisToAxisDescription(BivariateMatrixQuery.Axis axis);
@@ -216,6 +219,7 @@ public interface BivariateStatisticMapper {
             expression = "java(bivariateMatrixQueryStep1ListToBivariateLegendAxisStepList(x.steps()))")
     @Mapping(target = "quality", expression = "java(x.quality())")
     @Mapping(target = "transformation", ignore = true)
+    @Mapping(target = "datasetStats", ignore = true)
     @Mapping(target = "parent", expression = "java(x.parent())")
     @Mapping(target = "quotients", ignore = true)
     BivariateLegendAxisDescription bivariateMatrixQueryXAxisToAxisDescription(BivariateMatrixQuery.X x);
@@ -233,6 +237,7 @@ public interface BivariateStatisticMapper {
             expression = "java(bivariateMatrixQueryStep2ListToBivariateLegendAxisStepList(y.steps()))")
     @Mapping(target = "quality", expression = "java(y.quality())")
     @Mapping(target = "transformation", ignore = true)
+    @Mapping(target = "datasetStats", ignore = true)
     @Mapping(target = "parent", expression = "java(y.parent())")
     @Mapping(target = "quotients", ignore = true)
     BivariateLegendAxisDescription bivariateMatrixQueryYAxisToAxisDescription(BivariateMatrixQuery.Y y);

--- a/src/test/java/io/kontur/disasterninja/util/TestUtil.java
+++ b/src/test/java/io/kontur/disasterninja/util/TestUtil.java
@@ -27,9 +27,9 @@ public final class TestUtil {
 
         BivariateLegendAxes axes = new BivariateLegendAxes();
         axes.setX(new BivariateLegendAxisDescription("xLabel", null, null, null,
-                null, null, null));
+                null, null, null, null));
         axes.setY(new BivariateLegendAxisDescription("yLabel", null, null, null,
-                null, null, null));
+                null, null, null, null));
 
         Legend legend = new Legend("legendName", LegendType.SIMPLE, null, new ArrayList<>(),
                 Collections.singletonList(new ColorDto("A1", "rgb(232,232,157)")), axes,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `datasetStats` field to enhance the `AxisList` query, providing detailed statistical metrics (min, max, mean, stddev) related to datasets.
	- Added a new `DatasetStats` type to the GraphQL schema, enabling comprehensive data insights.

- **Refactor**
	- Improved data mapping within the `AxisListMapper` to effectively integrate dataset statistics.
	- Enhanced the `BivariateStatisticMapper` to refine mapping processes by excluding the `datasetStats` field as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->