### PR TITLE
add indicators param to /tiles

### DIFF
--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiClient.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiClient.java
@@ -4,7 +4,7 @@ import org.springframework.http.ResponseEntity;
 
 public interface InsightsApiClient {
 
-    ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass);
+    ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass, String indicators);
 
     ResponseEntity<byte[]> getBivariateTileMvtV2(Integer z, Integer x, Integer y, String indicatorsClass);
 }

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiClientDummy.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiClientDummy.java
@@ -5,7 +5,7 @@ import org.springframework.http.ResponseEntity;
 public class InsightsApiClientDummy implements InsightsApiClient {
 
     @Override
-    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass) {
+    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass, String indicators) {
         return ResponseEntity.ok()
                 .body(new byte[0]);
     }

--- a/src/main/java/io/kontur/disasterninja/client/InsightsApiClientImpl.java
+++ b/src/main/java/io/kontur/disasterninja/client/InsightsApiClientImpl.java
@@ -42,13 +42,13 @@ public class InsightsApiClientImpl implements InsightsApiClient {
 
     @Override
     @Timed(value = "insights.getBivariateTileMvt", histogram = true)
-    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass) {
+    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass, String indicators) {
         if ("all".equals(indicatorsClass)) {
             incrementForCorrectLabels(z, AUTHENTICATED);
         } else {
             incrementForCorrectLabels(z, NOT_AUTHENTICATED);
         }
-        return insightsApiRestTemplate.getForEntity(String.format(INSIGHTS_API_TILE_MVT_URI, z, x, y, indicatorsClass),
+        return insightsApiRestTemplate.getForEntity(String.format(INSIGHTS_API_TILE_MVT_URI + (indicators == null ? "" : "&indicators=" + indicators), z, x, y, indicatorsClass),
                 byte[].class);
     }
 

--- a/src/main/java/io/kontur/disasterninja/controller/TileController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/TileController.java
@@ -25,8 +25,9 @@ public class TileController {
             content = @Content(mediaType = "application/vnd.mapbox-vector-tile", schema = @Schema(implementation = byte[].class)))
     @GetMapping(value = "/bivariate/v1/{z}/{x}/{y}.mvt", produces = "application/vnd.mapbox-vector-tile")
     public ResponseEntity<byte[]> getBivariateTileMvt(@PathVariable Integer z, @PathVariable Integer x, @PathVariable Integer y,
-                               @RequestParam(defaultValue = "all") String indicatorsClass){
-        return tileService.getBivariateTileMvt(z, x, y, indicatorsClass);
+            @RequestParam(defaultValue = "all") String indicatorsClass,
+            @RequestParam(required = false) String indicators){
+        return tileService.getBivariateTileMvt(z, x, y, indicatorsClass, indicators);
     }
 
     @Operation(summary = "Returns bivariate mvt tile using z, x, y, indicator class and Insights API service version 2.",

--- a/src/main/java/io/kontur/disasterninja/service/TileService.java
+++ b/src/main/java/io/kontur/disasterninja/service/TileService.java
@@ -11,8 +11,8 @@ public class TileService {
 
     private final InsightsApiClient insightsApiClient;
 
-    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass){
-        return insightsApiClient.getBivariateTileMvt(z, x, y, indicatorsClass);
+    public ResponseEntity<byte[]> getBivariateTileMvt(Integer z, Integer x, Integer y, String indicatorsClass, String indicators){
+        return insightsApiClient.getBivariateTileMvt(z, x, y, indicatorsClass, indicators);
     }
 
     public ResponseEntity<byte[]> getBivariateTileMvtV2(Integer z, Integer x, Integer y, String indicatorsClass){

--- a/src/test/java/io/kontur/disasterninja/client/InsightsApiClientTest.java
+++ b/src/test/java/io/kontur/disasterninja/client/InsightsApiClientTest.java
@@ -57,7 +57,7 @@ class InsightsApiClientTest {
                         MediaType.parseMediaType("application/vnd.mapbox-vector-tile")));
 
         //when
-        byte[] tile = client.getBivariateTileMvt(z, x, y, "all").getBody();
+        byte[] tile = client.getBivariateTileMvt(z, x, y, "all", null).getBody();
 
         //then
         assertNotNull(tile);

--- a/src/test/java/io/kontur/disasterninja/service/TileServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/TileServiceTest.java
@@ -31,11 +31,11 @@ class TileServiceTest {
         Integer x = 8;
         Integer y = 6;
 
-        when(insightsApiClient.getBivariateTileMvt(z, x, y, "all")).thenReturn(result);
+        when(insightsApiClient.getBivariateTileMvt(z, x, y, "all", null)).thenReturn(result);
 
-        byte[] tile = service.getBivariateTileMvt(z, x, y, "all").getBody();
+        byte[] tile = service.getBivariateTileMvt(z, x, y, "all", null).getBody();
 
-        verify(insightsApiClient).getBivariateTileMvt(z, x, y, "all");
+        verify(insightsApiClient).getBivariateTileMvt(z, x, y, "all", null);
         assertEquals(100, tile.length);
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `getBivariateTileMvt` method to accept an additional optional parameter for indicators, allowing for more specific API requests.
  
- **Bug Fixes**
	- Updated method signatures across various components to ensure compatibility with the new parameter, improving overall functionality.

- **Tests**
	- Adjusted test cases to reflect the updated method signatures and verify the correct handling of the new parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->