### PR TITLE
21101 Add notifications enabled configuration

### DIFF
--- a/src/main/java/io/kontur/disasterninja/config/MailSenderConfiguration.java
+++ b/src/main/java/io/kontur/disasterninja/config/MailSenderConfiguration.java
@@ -14,7 +14,7 @@ import java.util.Properties;
 import static org.apache.commons.lang3.StringUtils.isAnyBlank;
 
 @Configuration
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.email.enabled")
 public class MailSenderConfiguration {
 
     private final static Logger LOG = LoggerFactory.getLogger(MailSenderConfiguration.class);

--- a/src/main/java/io/kontur/disasterninja/notifications/email/EmailMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/email/EmailMessageFormatter.java
@@ -23,7 +23,7 @@ import static java.time.ZoneOffset.UTC;
 import static org.apache.commons.lang3.text.WordUtils.capitalizeFully;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.email.enabled")
 public class EmailMessageFormatter extends MessageFormatter {
 
     private final static Logger LOG = LoggerFactory.getLogger(EmailMessageFormatter.class);

--- a/src/main/java/io/kontur/disasterninja/notifications/email/EmailNotificationService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/email/EmailNotificationService.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.email.enabled")
 public class EmailNotificationService extends NotificationService {
 
     private final static Logger LOG = LoggerFactory.getLogger(EmailNotificationService.class);

--- a/src/main/java/io/kontur/disasterninja/notifications/email/EmailSender.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/email/EmailSender.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import javax.mail.internet.MimeMessage;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.email.enabled")
 public class EmailSender {
 
     private final static Logger LOG = LoggerFactory.getLogger(EmailSender.class);

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import static io.kontur.disasterninja.util.FormatUtil.formatNumber;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.slack.enabled")
 public class SlackMessageFormatter extends MessageFormatter {
 
     private static final String BODY = "{\"text\":\"><%s|%s>%s\", \"unfurl_links\":true, \"unfurl_media\": true}";

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 import java.util.Map;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.slack.enabled")
 public class SlackNotificationService extends NotificationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SlackNotificationService.class);

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackSender.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackSender.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
 @Component
-@ConditionalOnProperty(value = "notifications.enabled")
+@ConditionalOnProperty(value = "notifications.slack.enabled")
 public class SlackSender {
 
     private final static Logger LOG = LoggerFactory.getLogger(SlackSender.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,10 @@ kontur:
 
 notifications:
   enabled: false
+  slack:
+    enabled: false
+  email:
+    enabled: false
 
 springdoc:
   writer-with-default-pretty-printer: true


### PR DESCRIPTION
I added a separate `email/slack.enabled` flag to add the possibility of turning off one type of notification completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced granular controls for notifications by separating email and Slack enablement, allowing for more precise activation.
	- Updated default settings now require explicit enablement for email and Slack notifications, offering users improved customization over notification preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->