### PR TITLE
20910-update-layers-api-to-support-json-type-for-copyrights-field-data

### DIFF
--- a/src/main/java/io/kontur/disasterninja/dto/layerapi/Collection.java
+++ b/src/main/java/io/kontur/disasterninja/dto/layerapi/Collection.java
@@ -26,7 +26,7 @@ public class Collection {
     private String description;
 
     @JsonProperty("copyrights")
-    private String copyrights;
+    private List<String> copyrights;
 
     @JsonProperty("properties")
     private ObjectNode properties;

--- a/src/main/java/io/kontur/disasterninja/service/layers/LayersApiService.java
+++ b/src/main/java/io/kontur/disasterninja/service/layers/LayersApiService.java
@@ -119,7 +119,7 @@ public class LayersApiService {
                 .legend(collection.getLegendStyle() != null ?
                         JsonUtil.readObjectNode(collection.getLegendStyle(), Legend.class) : null)
                 .mapStyle(collection.getMapStyle())
-                .copyrights(collection.getCopyrights() != null ? singletonList(collection.getCopyrights()) : null)
+                .copyrights(collection.getCopyrights())
                 .boundaryRequiredForRetrieval(boundaryRequiredForRetrieval)
                 .eventIdRequiredForRetrieval(eventIdRequiredForRetrieval)
                 .ownedByUser(collection.isOwnedByUser())

--- a/src/test/java/io/kontur/disasterninja/client/LayersApiClientTest.java
+++ b/src/test/java/io/kontur/disasterninja/client/LayersApiClientTest.java
@@ -182,7 +182,7 @@ class LayersApiClientTest extends TestDependingOnUserAuth {
         assertEquals("hotProjects", collection.getId());
         assertEquals("HOT Tasking Manager Projects", collection.getTitle());
         assertEquals("Projects on HOT Tasking manager, ongoing and historical", collection.getDescription());
-        assertEquals("(c) Kontur", collection.getCopyrights());
+        assertEquals(List.of("(c) Kontur"), collection.getCopyrights());
         assertEquals("overlay", collection.getCategory().getName());
         assertEquals("tiles", collection.getItemType());
         assertEquals("tiles", collection.getItemType());
@@ -306,7 +306,7 @@ class LayersApiClientTest extends TestDependingOnUserAuth {
         assertEquals("hotProjects", collection.getId());
         assertEquals("HOT Tasking Manager Projects", collection.getTitle());
         assertEquals("Projects on HOT Tasking manager, ongoing and historical", collection.getDescription());
-        assertEquals("(c) Kontur", collection.getCopyrights());
+        assertEquals(List.of("(c) Kontur"), collection.getCopyrights());
         assertEquals("overlay", collection.getCategory().getName());
         assertEquals("tiles", collection.getItemType());
         assertEquals("tiles", collection.getItemType());

--- a/src/test/java/io/kontur/disasterninja/dto/DtoTest.java
+++ b/src/test/java/io/kontur/disasterninja/dto/DtoTest.java
@@ -68,7 +68,10 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
+        Assertions.assertEquals(
+                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
+                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
+
     }
 
     @Test
@@ -120,7 +123,9 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
+        Assertions.assertEquals(
+                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
+                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
     }
 
     @Test
@@ -144,7 +149,9 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
+        Assertions.assertEquals(
+                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
+                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
     }
 
     private Layer testLayer(String id, FeatureCollection geoJSON) {

--- a/src/test/java/io/kontur/disasterninja/dto/DtoTest.java
+++ b/src/test/java/io/kontur/disasterninja/dto/DtoTest.java
@@ -68,9 +68,7 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(
-                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
-                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
+        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
 
     }
 
@@ -123,9 +121,7 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(
-                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
-                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
+        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
     }
 
     @Test
@@ -149,9 +145,7 @@ public class DtoTest {
         Assertions.assertEquals(layer.getGroup(), response.get(0).group());
         Assertions.assertEquals(layer.isBoundaryRequiredForRetrieval(),
                 response.get(0).boundaryRequiredForRetrieval());
-        Assertions.assertEquals(
-                layer.getCopyrights() != null ? layer.getCopyrights() : List.of(),
-                response.get(0).copyrights() != null ? response.get(0).copyrights() : List.of());
+        Assertions.assertEquals(layer.getCopyrights(), response.get(0).copyrights());
     }
 
     private Layer testLayer(String id, FeatureCollection geoJSON) {

--- a/src/test/java/io/kontur/disasterninja/service/layers/providers/LayersApiProviderIT.java
+++ b/src/test/java/io/kontur/disasterninja/service/layers/providers/LayersApiProviderIT.java
@@ -92,7 +92,7 @@ public class LayersApiProviderIT extends TestDependingOnUserAuth {
         assertEquals("Projects on HOT Tasking manager, ongoing and historical", layer.getDescription());
         assertEquals(LayerCategory.OVERLAY, layer.getCategory());
         assertEquals("group_1", layer.getGroup());
-        assertEquals(List.of("(c) Kontur"), collection.getCopyrights());
+        assertEquals(List.of("(c) Kontur"), layer.getCopyrights());
         assertEquals(LegendType.SIMPLE, layer.getLegend().getType());
         assertEquals("hotProjects", layer.getLegend().getSteps().get(0).getSourceLayer());
         assertEquals("#bbd1e6", layer.getLegend().getSteps().get(0).getStepIconFill());

--- a/src/test/java/io/kontur/disasterninja/service/layers/providers/LayersApiProviderIT.java
+++ b/src/test/java/io/kontur/disasterninja/service/layers/providers/LayersApiProviderIT.java
@@ -92,7 +92,7 @@ public class LayersApiProviderIT extends TestDependingOnUserAuth {
         assertEquals("Projects on HOT Tasking manager, ongoing and historical", layer.getDescription());
         assertEquals(LayerCategory.OVERLAY, layer.getCategory());
         assertEquals("group_1", layer.getGroup());
-        assertEquals("(c) Kontur", layer.getCopyrights().get(0));
+        assertEquals(List.of("(c) Kontur"), collection.getCopyrights());
         assertEquals(LegendType.SIMPLE, layer.getLegend().getType());
         assertEquals("hotProjects", layer.getLegend().getSteps().get(0).getSourceLayer());
         assertEquals("#bbd1e6", layer.getLegend().getSteps().get(0).getStepIconFill());

--- a/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.created.json
+++ b/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.created.json
@@ -2,7 +2,7 @@
   "id": "myId",
   "title": "layer title",
   "description": "An address.",
-  "copyrights": "string",
+  "copyrights": ["string"],
   "properties": {},
   "legendStyle": {"name":"legendName","type":"simple","linkProperty":null,"steps":[{"paramName":"param name","paramValue":"qwe","axis":null,"axisValue":null,"stepName":"step name","stepShape":"hex","style":{"prop":"value"},"sourceLayer":"source-layer","stepIconFill":"fill","stepIconStroke":"stroke"},{"paramName":"param name","paramValue":"asd","axis":null,"axisValue":null,"stepName":"step name2","stepShape":"hex","style":{"prop":"value"},"sourceLayer":"source-layer","stepIconFill":"","stepIconStroke":""}],"tooltip": {"type": "markdown","paramName": "tooltipContent"},"colors": [{"id":"A1","color":"rgb(232,232,157)"}],"axes":{"x":{"label": "xLabel"},"y":{"label": "yLabel"}}},
   "group": {

--- a/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.geojson.json
+++ b/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.geojson.json
@@ -4,7 +4,7 @@
       "id": "hotProjects_feature_type",
       "title": "HOT Tasking Manager Projects",
       "description": "Projects on HOT Tasking manager, ongoing and historical",
-      "copyrights": "(c) Kontur",
+      "copyrights": ["(c) Kontur"],
       "category": {
         "name": "overlay",
         "isOpened": false,

--- a/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.vector.json
+++ b/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layer.vector.json
@@ -2,7 +2,7 @@
   "id": "hotProjects",
   "title": "HOT Tasking Manager Projects",
   "description": "Projects on HOT Tasking manager, ongoing and historical",
-  "copyrights": "(c) Kontur",
+  "copyrights": ["(c) Kontur"],
   "legendStyle": {
     "type": "simple",
     "steps": [

--- a/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layers.page1.json
+++ b/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.layers.page1.json
@@ -12,7 +12,7 @@
       "id": "hotProjects",
       "title": "HOT Tasking Manager Projects",
       "description": "Projects on HOT Tasking manager, ongoing and historical",
-      "copyrights": "(c) Kontur",
+      "copyrights": ["(c) Kontur"],
       "legendStyle": {
         "type": "simple",
         "steps": [

--- a/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.search.hotProjects.response.json
+++ b/src/test/resources/io/kontur/disasterninja/client/layers/layersAPI.search.hotProjects.response.json
@@ -4,7 +4,7 @@
       "id": "hotProjects",
       "title": "HOT Tasking Manager Projects",
       "description": "Projects on HOT Tasking manager, ongoing and historical",
-      "copyrights": "(c) Kontur",
+      "copyrights": ["(c) Kontur"],
       "legendStyle": {
         "type": "simple",
         "steps": [

--- a/src/test/resources/io/kontur/disasterninja/controller/layers-api/apps.defaultLayers.json
+++ b/src/test/resources/io/kontur/disasterninja/controller/layers-api/apps.defaultLayers.json
@@ -6,7 +6,7 @@
       "id": "hotProjects",
       "title": "HOT Tasking Manager Projects",
       "description": "Projects on HOT Tasking manager, ongoing and historical",
-      "copyrights": "© Humanitarian OpenStreetMap Team, © Kontur",
+      "copyrights": ["© Humanitarian OpenStreetMap Team", "© Kontur"],
       "links": [
         {
           "href": "https://test-api02.konturlabs.com/tiles/public.hot_projects/{z}/{x}/{y}.pbf",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The platform now supports multiple copyright entries. API responses and data representations have been updated to return arrays of attribution values rather than a single entry, offering improved flexibility and consistency in how copyright information is displayed across collections and layers.
- **Bug Fixes**
	- Adjusted test assertions to validate the new array format for copyright fields, ensuring consistency across different test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->