### PR TITLE
21266 Change event shape color to red

### DIFF
--- a/src/main/resources/layers/layerconfig.yaml
+++ b/src/main/resources/layers/layerconfig.yaml
@@ -333,7 +333,7 @@ configs:
           style:
             width: 2
             color: '#D52627'
-            opacity: 0.5
+            opacity: 0.6
 
   - id: 'eventShape.WILDFIRE'
     globalOverlay: false
@@ -374,7 +374,7 @@ configs:
           style:
             width: 3
             color: '#D52627'
-            opacity: 0.5
+            opacity: 0.6
 
   - id: 'eventShape.VOLCANO'
     globalOverlay: false

--- a/src/main/resources/layers/layerconfig.yaml
+++ b/src/main/resources/layers/layerconfig.yaml
@@ -18,7 +18,7 @@ configs:
           stepShape: 'circle'
           style:
             width: 3
-            color: '#58211B'
+            color: '#A72C26'
 
   ## Event Shape: configs per event type
   - id: 'eventShape.CYCLONE'
@@ -131,7 +131,7 @@ configs:
           paramValue: 'globalArea'
           style:
             width: 3
-            color: '#58211B'
+            color: '#A72C26'
 
   - id: 'eventShape.EARTHQUAKE'
     globalOverlay: false
@@ -324,7 +324,7 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#58211B'
+            color: '#A72C26'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
@@ -366,7 +366,7 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#58211B'
+            color: '#A72C26'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
@@ -406,7 +406,7 @@ configs:
           paramValue: 0
           style:
             width: 2
-            color: '#58211B'
+            color: '#A72C26'
             opacity: 0.8
         - stepName: '6 hours Forecast'
           stepShape: 'circle'
@@ -414,7 +414,7 @@ configs:
           paramValue: 6
           style:
             width: 2
-            color: '#58211B'
+            color: '#A72C26'
             opacity: 0.6
         - stepName: '12 hours Forecast'
           stepShape: 'circle'
@@ -422,7 +422,7 @@ configs:
           paramValue: 12
           style:
             width: 2
-            color: '#58211B'
+            color: '#A72C26'
             opacity: 0.4
         - stepName: '18 hours Forecast'
           stepShape: 'circle'
@@ -430,7 +430,7 @@ configs:
           paramValue: 18
           style:
             width: 2
-            color: '#58211B'
+            color: '#A72C26'
             opacity: 0.2
         - stepName: 'Initial Forecast'
           stepShape: 'circle'
@@ -438,7 +438,7 @@ configs:
           paramValue: 'Poly_Cones_0'
           style:
             width: 2
-            color: '#58211B'
+            color: '#A72C26'
             opacity: 0.8
 
   # --- empty template ---

--- a/src/main/resources/layers/layerconfig.yaml
+++ b/src/main/resources/layers/layerconfig.yaml
@@ -18,7 +18,7 @@ configs:
           stepShape: 'circle'
           style:
             width: 3
-            color: '#A72C26'
+            color: '#D52627'
 
   ## Event Shape: configs per event type
   - id: 'eventShape.CYCLONE'
@@ -131,7 +131,7 @@ configs:
           paramValue: 'globalArea'
           style:
             width: 3
-            color: '#A72C26'
+            color: '#D52627'
 
   - id: 'eventShape.EARTHQUAKE'
     globalOverlay: false
@@ -324,7 +324,7 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#A72C26'
+            color: '#D52627'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
@@ -332,7 +332,7 @@ configs:
           paramValue: 'globalArea'
           style:
             width: 2
-            color: '#051626'
+            color: '#D52627'
             opacity: 0.5
 
   - id: 'eventShape.WILDFIRE'
@@ -366,14 +366,15 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#A72C26'
+            color: '#D52627'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
           paramValue: 'alertArea'
           style:
             width: 3
-            color: '#051626'
+            color: '#D52627'
+            opacity: 0.5
 
   - id: 'eventShape.VOLCANO'
     globalOverlay: false
@@ -406,7 +407,7 @@ configs:
           paramValue: 0
           style:
             width: 2
-            color: '#A72C26'
+            color: '#D52627'
             opacity: 0.8
         - stepName: '6 hours Forecast'
           stepShape: 'circle'
@@ -414,7 +415,7 @@ configs:
           paramValue: 6
           style:
             width: 2
-            color: '#A72C26'
+            color: '#D52627'
             opacity: 0.6
         - stepName: '12 hours Forecast'
           stepShape: 'circle'
@@ -422,7 +423,7 @@ configs:
           paramValue: 12
           style:
             width: 2
-            color: '#A72C26'
+            color: '#D52627'
             opacity: 0.4
         - stepName: '18 hours Forecast'
           stepShape: 'circle'
@@ -430,7 +431,7 @@ configs:
           paramValue: 18
           style:
             width: 2
-            color: '#A72C26'
+            color: '#D52627'
             opacity: 0.2
         - stepName: 'Initial Forecast'
           stepShape: 'circle'
@@ -438,7 +439,7 @@ configs:
           paramValue: 'Poly_Cones_0'
           style:
             width: 2
-            color: '#A72C26'
+            color: '#D52627'
             opacity: 0.8
 
   # --- empty template ---

--- a/src/main/resources/layers/layerconfig.yaml
+++ b/src/main/resources/layers/layerconfig.yaml
@@ -18,7 +18,7 @@ configs:
           stepShape: 'circle'
           style:
             width: 3
-            color: '#051626'
+            color: '#58211B'
 
   ## Event Shape: configs per event type
   - id: 'eventShape.CYCLONE'
@@ -131,7 +131,7 @@ configs:
           paramValue: 'globalArea'
           style:
             width: 3
-            color: '#051626'
+            color: '#58211B'
 
   - id: 'eventShape.EARTHQUAKE'
     globalOverlay: false
@@ -324,7 +324,7 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#051626'
+            color: '#58211B'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
@@ -366,7 +366,7 @@ configs:
           paramValue: 'exposure'
           style:
             width: 3
-            color: '#051626'
+            color: '#58211B'
         - stepName: 'Alert Area'
           stepShape: 'circle'
           paramName: 'areaType'
@@ -406,7 +406,7 @@ configs:
           paramValue: 0
           style:
             width: 2
-            color: '#051626'
+            color: '#58211B'
             opacity: 0.8
         - stepName: '6 hours Forecast'
           stepShape: 'circle'
@@ -414,7 +414,7 @@ configs:
           paramValue: 6
           style:
             width: 2
-            color: '#051626'
+            color: '#58211B'
             opacity: 0.6
         - stepName: '12 hours Forecast'
           stepShape: 'circle'
@@ -422,7 +422,7 @@ configs:
           paramValue: 12
           style:
             width: 2
-            color: '#051626'
+            color: '#58211B'
             opacity: 0.4
         - stepName: '18 hours Forecast'
           stepShape: 'circle'
@@ -430,7 +430,7 @@ configs:
           paramValue: 18
           style:
             width: 2
-            color: '#051626'
+            color: '#58211B'
             opacity: 0.2
         - stepName: 'Initial Forecast'
           stepShape: 'circle'
@@ -438,7 +438,7 @@ configs:
           paramValue: 'Poly_Cones_0'
           style:
             width: 2
-            color: '#051626'
+            color: '#58211B'
             opacity: 0.8
 
   # --- empty template ---


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the color scheme for several event shapes (including default, drought, flood, wildfire, and volcano) to a dark red tone for improved visual distinction.
  - Increased opacity for the alert area in flood and wildfire event shapes for enhanced visual layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->