### PR TITLE
Optimize event endpoint shape layer

### DIFF
--- a/src/main/java/io/kontur/disasterninja/dto/EventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventDto.java
@@ -3,6 +3,8 @@ package io.kontur.disasterninja.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.wololo.geojson.FeatureCollection;
+import io.kontur.disasterninja.dto.layer.LayerDetailsDto;
+import io.kontur.disasterninja.dto.layer.LayerSummaryDto;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -30,5 +32,12 @@ public class EventDto {
     private List<Double> bbox;
     private List<Double> centroid;
     private int episodeCount;
+    private AssociatedLayer associatedLayer;
+
+    @Data
+    public static class AssociatedLayer {
+        private LayerDetailsDto mapData;
+        private LayerSummaryDto layerInfo;
+    }
 
 }

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
@@ -61,7 +61,7 @@ public class EventDtoConverter {
             }
         }
 
-        dto.setGeojson(uniteGeometry(event));
+        dto.setGeojson(event.getGeometries());
         dto.setLatestEpisodeGeojson(event.getGeometries());
         dto.setUpdatedAt(event.getUpdatedAt());
 
@@ -84,19 +84,4 @@ public class EventDtoConverter {
         return result;
     }
 
-    private static FeatureCollection uniteGeometry(EventApiEventDto event) {
-        FeatureCollection geom = event.getGeometries();
-        if (geom == null || geom.getFeatures() == null || geom.getFeatures().length == 0) {
-            return new FeatureCollection(new Feature[0]);
-        }
-        Feature[] episodeFeatures = geom.getFeatures();
-        List<Geometry> episodeGeometries = new ArrayList<>(episodeFeatures.length);
-        Stream.of(episodeFeatures).forEach(f -> episodeGeometries.add(geoJSONReader.read(f.getGeometry())));
-
-        GeometryFactory geometryFactory = new GeometryFactory(episodeGeometries.get(0).getPrecisionModel());
-        org.locationtech.jts.geom.Geometry unitedGeometry = geometryFactory
-                .createGeometryCollection(episodeGeometries.toArray(new org.locationtech.jts.geom.Geometry[0]))
-                .union();
-        return new FeatureCollection(new Feature[]{new Feature(geoJSONWriter.write(unitedGeometry), emptyMap())});
-    }
 }

--- a/src/main/java/io/kontur/disasterninja/service/layers/providers/EventShapeLayerProvider.java
+++ b/src/main/java/io/kontur/disasterninja/service/layers/providers/EventShapeLayerProvider.java
@@ -47,11 +47,7 @@ public class EventShapeLayerProvider implements LayerProvider {
     @Override
     @Timed(value = "layers.obtainSelectedAreaLayers", histogram = true)
     public CompletableFuture<List<Layer>> obtainSelectedAreaLayers(LayerSearchParams searchParams) {
-        if (searchParams.getEventId() == null || searchParams.getEventFeed() == null) {
-            return CompletableFuture.completedFuture(Collections.emptyList());
-        }
-        Layer layer = obtainLayer(EVENT_SHAPE_LAYER_ID, searchParams);
-        return CompletableFuture.completedFuture(layer == null ? Collections.emptyList() : List.of(layer));
+        return CompletableFuture.completedFuture(Collections.emptyList());
     }
 
     @Override
@@ -85,7 +81,7 @@ public class EventShapeLayerProvider implements LayerProvider {
                 .id(EVENT_SHAPE_LAYER_ID)
                 .source(LayerSource.builder()
                         .type(GEOJSON)
-                        .data(eventDto.getLatestEpisodeGeojson()) //sic!
+                        .data(eventDto.getGeojson())
                         .build())
                 .eventIdRequiredForRetrieval(true)
                 .build();

--- a/src/test/java/io/kontur/disasterninja/service/EventApiServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/EventApiServiceTest.java
@@ -24,6 +24,8 @@ import org.wololo.geojson.Feature;
 import org.wololo.geojson.FeatureCollection;
 import uk.co.jemos.podam.api.PodamFactory;
 import uk.co.jemos.podam.api.PodamFactoryImpl;
+import io.kontur.disasterninja.service.layers.LocalLayerConfigService;
+import org.springframework.core.io.ClassPathResource;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
@@ -54,11 +56,14 @@ class EventApiServiceTest {
     @Mock
     private KeycloakAuthorizationService authorizationService;
     private EventApiClient client = mock(EventApiClient.class);
-    private EventApiService service = new EventApiService(client, 1000);
+    private EventApiService service;
+    private LocalLayerConfigService layerConfigService;
 
     @BeforeEach
     public void before() {
         when(authorizationService.getAccessToken()).thenReturn(defaultAppToken);
+        layerConfigService = new LocalLayerConfigService(new org.springframework.core.io.ClassPathResource("/layers/layerconfig.yaml"), "", "dev");
+        service = new EventApiService(client, layerConfigService, 1000);
     }
 
     public void givenJwtTokenIs(String tokenValue) {
@@ -164,7 +169,7 @@ class EventApiServiceTest {
     @Test
     public void testGetEvents_GetWithoutAfterFilter() {
         //given
-        EventApiService localService = new EventApiService(client, 3);
+        EventApiService localService = new EventApiService(client, layerConfigService, 3);
         PodamFactory factory = new PodamFactoryImpl();
 
         EventApiClient.EventApiSearchEventResponse eventResponse = new EventApiClient.EventApiSearchEventResponse();
@@ -193,7 +198,7 @@ class EventApiServiceTest {
     @Test
     public void testGetEvents_Get4DayEventsInOneCall() {
         //given
-        EventApiService localService = new EventApiService(client, 3);
+        EventApiService localService = new EventApiService(client, layerConfigService, 3);
         PodamFactory factory = new PodamFactoryImpl();
         EventApiEventDto event1 = factory.manufacturePojo(EventApiEventDto.class);
         EventApiEventDto event2 = factory.manufacturePojo(EventApiEventDto.class);
@@ -220,7 +225,7 @@ class EventApiServiceTest {
     @Test
     public void testGetEvents_Get4DayEventsInTwoCalls() {
         //given
-        EventApiService localService = new EventApiService(client, 3);
+        EventApiService localService = new EventApiService(client, layerConfigService, 3);
         PodamFactory factory = new PodamFactoryImpl();
         EventApiEventDto event1 = factory.manufacturePojo(EventApiEventDto.class);
         EventApiEventDto event2 = factory.manufacturePojo(EventApiEventDto.class);
@@ -253,7 +258,7 @@ class EventApiServiceTest {
     @Test
     public void testGetEvents_Get4DayEventsInThreeCalls() {
         //given
-        EventApiService localService = new EventApiService(client, 3);
+        EventApiService localService = new EventApiService(client, layerConfigService, 3);
         PodamFactory factory = new PodamFactoryImpl();
 
         EventApiClient.EventApiSearchEventResponse eventResponse = new EventApiClient.EventApiSearchEventResponse();

--- a/src/test/java/io/kontur/disasterninja/service/layers/LayerServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/layers/LayerServiceTest.java
@@ -130,12 +130,14 @@ public class LayerServiceTest {
 
         when(eventApiProvider.obtainLayer(any(), any())).thenReturn(layer);
 
-        List<Layer> result = layerService.get(Collections.emptyList(), List.of(layer.getId()),
-                paramsWithSomeBoundary());
-        verify(eventApiProvider, times(1)).obtainLayer(eq(layer.getId()),
-                any());
-
-        assertEquals(1, result.size());
+        try {
+            layerService.get(Collections.emptyList(), List.of(layer.getId()),
+                    paramsWithSomeBoundary());
+            fail("Expected exception not thrown");
+        } catch (WebApplicationException e) {
+            verify(eventApiProvider, times(0)).obtainLayer(eq(layer.getId()), any());
+            assertEquals("Layer not found / no layer data found by id and boundary!", e.getMessage());
+        }
     }
 
     @Test

--- a/src/test/java/io/kontur/disasterninja/service/layers/providers/EventShapeLayerProvTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/layers/providers/EventShapeLayerProvTest.java
@@ -87,15 +87,7 @@ public class EventShapeLayerProvTest extends LayerProvidersTest {
     @Test
     public void obtainSelectedAreaLayersTest() throws ExecutionException, InterruptedException {
         List<Layer> layers = eventShapeLayerProvider.obtainSelectedAreaLayers(someEventIdEventFeedParams()).get();
-        assertEquals(1, layers.size());
-
-        Layer layer = layers.get(0);
-        Assertions.assertEquals(EVENT_SHAPE_LAYER_ID, layer.getId());
-        Assertions.assertEquals(EARTHQUAKE, layer.getEventType());
-        //check source data was loaded
-        Assertions.assertEquals(2, layer.getSource().getData().getFeatures().length);
-        Assertions.assertEquals("Point", layer.getSource().getData().getFeatures()[0].getGeometry().getType());
-        Assertions.assertEquals("Polygon", layer.getSource().getData().getFeatures()[1].getGeometry().getType());
+        assertTrue(layers.isEmpty());
     }
 
     @Test
@@ -150,11 +142,7 @@ public class EventShapeLayerProvTest extends LayerProvidersTest {
         Mockito.when(eventApiService.getEvent(any(), any())).thenReturn(eventDto);
 
         List<Layer> result = eventShapeLayerProvider.obtainSelectedAreaLayers(someEventIdEventFeedParams()).get();
-        assertEquals(1, result.size());
-
-        Assertions.assertEquals(EVENT_SHAPE_LAYER_ID, result.get(0).getId());
-        Assertions.assertNull(result.get(0).getEventType());
-        Assertions.assertTrue(result.get(0).isEventIdRequiredForRetrieval());
+        assertTrue(result.isEmpty());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include event shape layer info in EventDto
- return event geometry directly from Event API
- exclude event shape layer from layers search
- update tests

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6851b1e408a88324a3c4c513f5cc6296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Event details now include associated map layer information, providing enriched event data for users.

- **Bug Fixes**
  - Event map layers now consistently use the main event geometry for display.

- **Tests**
  - Updated tests to reflect changes in event layer association and geometry handling, ensuring accurate validation of new behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->