### PR TITLE
Add OSM gap analytics to email templates

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/email/EmailMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/email/EmailMessageFormatter.java
@@ -47,8 +47,8 @@ public class EmailMessageFormatter extends MessageFormatter {
         FeedEpisode lastEpisode = getLatestEpisode(event);
         return new EmailDto(
                 createSubject(event, lastEpisode),
-                generateTemplate("gg-email-template.txt", event, lastEpisode, urbanPopulationProperties, partners),
-                generateTemplate("gg-email-template.html", event, lastEpisode, urbanPopulationProperties, partners));
+                generateTemplate("gg-email-template.txt", event, lastEpisode, urbanPopulationProperties, analytics, partners),
+                generateTemplate("gg-email-template.html", event, lastEpisode, urbanPopulationProperties, analytics, partners));
     }
 
     private String createSubject(EventApiEventDto event, FeedEpisode lastEpisode) {
@@ -58,7 +58,9 @@ public class EmailMessageFormatter extends MessageFormatter {
         return sb.toString();
     }
 
-    public String generateTemplate(String template, EventApiEventDto event, FeedEpisode lastEpisode, Map<String, Object> urbanPopulationProperties, List<Partner> partners) {
+    public String generateTemplate(String template, EventApiEventDto event, FeedEpisode lastEpisode,
+                                   Map<String, Object> urbanPopulationProperties,
+                                   Map<String, Double> analytics, List<Partner> partners) {
         Context context = new Context();
         context.setVariable("link", String.format(konturUrlPattern, event.getEventId(), feed));
         context.setVariable("description", lastEpisode.getDescription());
@@ -68,6 +70,13 @@ public class EmailMessageFormatter extends MessageFormatter {
         context.setVariable("populatedArea", formatNumber(lastEpisode.getEpisodeDetails().get("populatedAreaKm2")));
         context.setVariable("industrialArea", formatNumber(lastEpisode.getEpisodeDetails().get("industrialAreaKm2")));
         context.setVariable("forestArea", formatNumber(lastEpisode.getEpisodeDetails().get("forestAreaKm2")));
+        context.setVariable("osmGapsArea", formatNumber(analytics.get("osmGapsArea")));
+        context.setVariable("osmGapsPercentage", formatNumber(analytics.get("osmGapsPercentage")));
+        context.setVariable("osmGapsPopulation", formatNumber(analytics.get("osmGapsPopulation")));
+        context.setVariable("noBuildingsArea", formatNumber(analytics.get("noBuildingsArea")));
+        context.setVariable("noBuildingsPopulation", formatNumber(analytics.get("noBuildingsPopulation")));
+        context.setVariable("noRoadsArea", formatNumber(analytics.get("noRoadsArea")));
+        context.setVariable("noRoadsPopulation", formatNumber(analytics.get("noRoadsPopulation")));
         context.setVariable("type", capitalizeFully(event.getType()));
         context.setVariable("severity", capitalizeFully(event.getSeverity().name()));
         context.setVariable("location", event.getLocation());

--- a/src/main/resources/notification/gg-email-template.html
+++ b/src/main/resources/notification/gg-email-template.html
@@ -66,6 +66,21 @@
         </ul>
     </div>
 
+    <div class="section" th:if="${osmGapsArea != '0' && osmGapsPopulation != '0' || noBuildingsArea != '0' && noBuildingsPopulation != '0' || noRoadsArea != '0' && noRoadsPopulation != '0'}">
+        <h3>🗺️ OpenStreetMap Gaps</h3>
+        <ul>
+            <li th:if="${osmGapsArea != '0' && osmGapsPopulation != '0'}">
+                <strong>Map gaps:</strong> <span th:text="${osmGapsArea}"></span> km² (<span th:text="${osmGapsPercentage}"></span>%) for <span th:text="${osmGapsPopulation}"></span> people
+            </li>
+            <li th:if="${noBuildingsArea != '0' && noBuildingsPopulation != '0'}">
+                <strong>Buildings map gaps:</strong> <span th:text="${noBuildingsArea}"></span> km² for <span th:text="${noBuildingsPopulation}"></span> people
+            </li>
+            <li th:if="${noRoadsArea != '0' && noRoadsPopulation != '0'}">
+                <strong>Roads map gaps:</strong> <span th:text="${noRoadsArea}"></span> km² for <span th:text="${noRoadsPopulation}"></span> people
+            </li>
+        </ul>
+    </div>
+
     <div class="section" th:if="${type != null || severity != null || startedAt != null || updatedAt != null || location != null}">
         <h3>🗓️ Event Status</h3>
         <ul>

--- a/src/main/resources/notification/gg-email-template.txt
+++ b/src/main/resources/notification/gg-email-template.txt
@@ -8,6 +8,12 @@ Impact Summary:
     [# th:if="${industrialArea != null}"]- Industrial area: [(${industrialArea})] km².[/]
     [# th:if="${forestArea != null}"]- Forest area: [(${forestArea})] km².[/]
 [/]
+[# th:if="${osmGapsArea != '0' && osmGapsPopulation != '0' || noBuildingsArea != '0' && noBuildingsPopulation != '0' || noRoadsArea != '0' && noRoadsPopulation != '0'}"]
+OpenStreetMap gaps:
+    [# th:if="${osmGapsArea != '0' && osmGapsPopulation != '0'}"]- Map gaps: [(${osmGapsArea})] km² ([(${osmGapsPercentage})]%) for [(${osmGapsPopulation})] people.[/]
+    [# th:if="${noBuildingsArea != '0' && noBuildingsPopulation != '0'}"]- Buildings map gaps: [(${noBuildingsArea})] km² for [(${noBuildingsPopulation})] people.[/]
+    [# th:if="${noRoadsArea != '0' && noRoadsPopulation != '0'}"]- Roads map gaps: [(${noRoadsArea})] km² for [(${noRoadsPopulation})] people.[/]
+[/]
 [# th:if="${type != null || severity != null || startedAt != null || updatedAt != null || location != null}"]
 Event Status:
     [# th:if="${type != null}"]- Type: [(${type})].[/]


### PR DESCRIPTION
## Summary
- add OSM gap metrics to email notification templates
- handle analytics values in `EmailMessageFormatter`

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6851b1ee53ec83249bbfe22f1a47f548