### PR TITLE
Add geometry filter for Event API

### DIFF
--- a/src/main/java/io/kontur/disasterninja/controller/EventsController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/EventsController.java
@@ -6,6 +6,7 @@ import io.kontur.disasterninja.dto.EventDto;
 import io.kontur.disasterninja.dto.EventEpisodeListDto;
 import io.kontur.disasterninja.dto.EventFeedDto;
 import io.kontur.disasterninja.dto.EventListDto;
+import io.kontur.disasterninja.dto.GeometryFilterType;
 import io.kontur.disasterninja.service.EventApiService;
 import io.kontur.disasterninja.service.UserProfileService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,9 +57,12 @@ public class EventsController {
                     "The coordinate reference system of the values is WGS 84 longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84). For WGS 84 longitude/latitude the values are the sequence of minimum longitude, minimum latitude, maximum longitude and maximum latitude.")
             @RequestParam(required = false)
             @ValidBbox
-            List<BigDecimal> bbox
+            List<BigDecimal> bbox,
+            @Parameter(description = "Geometry filter type", example = "ALL")
+            @RequestParam(defaultValue = "ALL")
+            GeometryFilterType geometryFilterType
     ) {
-        List<EventListDto> events = service.getEvents(feed, bbox);
+        List<EventListDto> events = service.getEvents(feed, bbox, geometryFilterType);
         if (offset >= events.size()) {
             throw new WebApplicationException("Offset is larger than resultset size", HttpStatus.NO_CONTENT);
         }
@@ -73,8 +77,9 @@ public class EventsController {
     @ApiResponse(responseCode = "200", description = "Successful operation", content = @Content(mediaType = "application/json", schema = @Schema(implementation = EventDto.class)))
     @ApiResponse(responseCode = "404", description = "Event is not found", content = @Content(mediaType = "application/json"))
     @GetMapping("/{feed}/{eventId}")
-    public EventDto getEvent(@PathVariable UUID eventId, @PathVariable String feed) {
-        return service.getEvent(eventId, feed);
+    public EventDto getEvent(@PathVariable UUID eventId, @PathVariable String feed,
+                             @RequestParam(defaultValue = "ALL") GeometryFilterType geometryFilterType) {
+        return service.getEvent(eventId, feed, geometryFilterType);
     }
 
     @Operation(tags = "Events", summary = "Returns event episodes")

--- a/src/main/java/io/kontur/disasterninja/dto/GeometryFilterType.java
+++ b/src/main/java/io/kontur/disasterninja/dto/GeometryFilterType.java
@@ -1,0 +1,6 @@
+package io.kontur.disasterninja.dto;
+
+public enum GeometryFilterType {
+    ALL,
+    NONE
+}

--- a/src/test/java/io/kontur/disasterninja/client/EventApiClientTest.java
+++ b/src/test/java/io/kontur/disasterninja/client/EventApiClientTest.java
@@ -1,5 +1,6 @@
 package io.kontur.disasterninja.client;
 
+import io.kontur.disasterninja.dto.GeometryFilterType;
 import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +50,8 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         server.expect(ExpectedCount.times(2), r -> assertThat(r.getURI().toString(),
                         matchesRegex(Pattern.compile(
                                 "/v1/\\?feed=testFeedName&severities=EXTREME,SEVERE,MODERATE&limit=1000" +
-                                        "&episodeFilterType=NONE&sortOrder=ASC&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:\\d{2}:\\d{2}.\\d+Z"))))
+                                        "&episodeFilterType=NONE&sortOrder=ASC&geometryFilterType=ALL" +
+                                        "&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:\\d{2}:\\d{2}.\\d+Z"))))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + getUserToken()))
                 .andRespond(r -> {
@@ -76,7 +78,8 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         server.expect(ExpectedCount.times(2), r -> assertThat(r.getURI().toString(),
                         matchesRegex(Pattern.compile(
                                 "/v1/\\?feed=testFeedName&severities=EXTREME,SEVERE,MODERATE&limit=1000" +
-                                        "&episodeFilterType=NONE&sortOrder=ASC&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:00:00Z"))))
+                                        "&episodeFilterType=NONE&sortOrder=ASC&geometryFilterType=ALL" +
+                                        "&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:00:00Z"))))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + getUserToken()))
                 .andRespond(r -> {
@@ -104,7 +107,8 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         server.expect(ExpectedCount.times(2), r -> assertThat(r.getURI().toString(),
                         matchesRegex(Pattern.compile(
                                 "/v1/\\?feed=testFeedName&severities=EXTREME,SEVERE,MODERATE&limit=1000" +
-                                        "&episodeFilterType=NONE&sortOrder=DESC&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:\\d{2}:\\d{2}.\\d+Z" +
+                                        "&episodeFilterType=NONE&sortOrder=DESC&geometryFilterType=ALL" +
+                                        "&after=\\d{4}-\\d{2}-\\d{2}[tT]\\d{2}:\\d{2}:\\d{2}.\\d+Z" +
                                         "&bbox=1.1&bbox=2.2&bbox=3.3&bbox=4.4"))))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + getUserToken()))
@@ -133,7 +137,8 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         server.expect(ExpectedCount.times(2), r -> assertThat(r.getURI().toString(),
                         matchesRegex(Pattern.compile(
                                 "/v1/\\?feed=testFeedName&severities=EXTREME,SEVERE,MODERATE&limit=1000" +
-                                        "&episodeFilterType=NONE&sortOrder=ASC&bbox=1.1&bbox=2.2&bbox=3.3&bbox=4.4"))))
+                                        "&episodeFilterType=NONE&sortOrder=ASC&geometryFilterType=ALL" +
+                                        "&bbox=1.1&bbox=2.2&bbox=3.3&bbox=4.4"))))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer " + getUserToken()))
                 .andRespond(r -> {
@@ -184,14 +189,14 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         //given
         givenJwtTokenIs("JwtTestToken");
         server.expect(ExpectedCount.once(),
-                        requestTo("/v1/event?feed=testFeedName&eventId=1ec05e2b-7d18-490c-ac9f-c33609fdc7a7&episodeFilterType=ANY"))
+                        requestTo("/v1/event?feed=testFeedName&eventId=1ec05e2b-7d18-490c-ac9f-c33609fdc7a7&episodeFilterType=ANY&geometryFilterType=ALL"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + getUserToken()))
                 .andRespond(withSuccess(readFile(this, "EventApiClientTest.testGetEvent.response.json"),
                         MediaType.APPLICATION_JSON));
         //when
         EventApiEventDto event = client.getEvent(UUID.fromString("1ec05e2b-7d18-490c-ac9f-c33609fdc7a7"),
-                "testFeedName", true);
+                "testFeedName", true, GeometryFilterType.ALL);
 
         //then
         verify(securityContext, times(1)).getAuthentication();
@@ -204,14 +209,14 @@ class EventApiClientTest extends TestDependingOnUserAuth {
         //given
         givenJwtTokenIs("JwtTestToken");
         server.expect(ExpectedCount.once(),
-                        requestTo("/v1/event?feed=testFeedName&eventId=1ec05e2b-7d18-490c-ac9f-c33609fdc7a7&episodeFilterType=NONE"))
+                        requestTo("/v1/event?feed=testFeedName&eventId=1ec05e2b-7d18-490c-ac9f-c33609fdc7a7&episodeFilterType=NONE&geometryFilterType=ALL"))
                 .andExpect(method(HttpMethod.GET))
                 .andExpect(header("Authorization", "Bearer " + getUserToken()))
                 .andRespond(withSuccess(readFile(this, "EventApiClientTest.testGetEvent.response.json"),
                         MediaType.APPLICATION_JSON));
         //when
         EventApiEventDto event = client.getEvent(UUID.fromString("1ec05e2b-7d18-490c-ac9f-c33609fdc7a7"),
-                "testFeedName", false);
+                "testFeedName", false, GeometryFilterType.ALL);
 
         //then
         verify(securityContext, times(1)).getAuthentication();

--- a/src/test/java/io/kontur/disasterninja/service/EventApiServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/EventApiServiceTest.java
@@ -122,8 +122,10 @@ class EventApiServiceTest {
         EventApiClient.EventApiSearchEventResponse eventResponse = new EventApiClient.EventApiSearchEventResponse();
         eventResponse.setData(List.of(moreRecentEvent, oldEvent, mostPopulatedEvent));
         eventResponse.setPageMetadata(new EventApiClient.PageMetadata());
-        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(1000), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
-        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(1000), eq(EventApiClient.SortOrder.DESC))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(1000),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(1000),
+                eq(EventApiClient.SortOrder.DESC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
 
         //when
         List<EventListDto> events = service.getEvents("feed", null);
@@ -148,11 +150,13 @@ class EventApiServiceTest {
         eventResponse.setData(Collections.emptyList());
         eventResponse.setPageMetadata(new EventApiClient.PageMetadata());
 
-        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(1000), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(1000),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
 
         EventApiClient.EventApiSearchEventResponse eventResponse2 = new EventApiClient.EventApiSearchEventResponse();
         eventResponse2.setPageMetadata(new EventApiClient.PageMetadata());
-        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(1000), eq(EventApiClient.SortOrder.DESC))).thenReturn(Optional.of(eventResponse2));
+        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(1000),
+                eq(EventApiClient.SortOrder.DESC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse2));
 
         //when
         List<EventListDto> events = service.getEvents("feed", null);
@@ -174,13 +178,15 @@ class EventApiServiceTest {
         pageMetadata.setNextAfterValue(now);
         eventResponse.setPageMetadata(pageMetadata);
 
-        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
 
         EventApiClient.EventApiSearchEventResponse eventResponse2 = new EventApiClient.EventApiSearchEventResponse();
         eventResponse2.setData(List.of(factory.manufacturePojo(EventApiEventDto.class)));
         EventApiClient.PageMetadata pageMetadata2 = new EventApiClient.PageMetadata();
         eventResponse2.setPageMetadata(pageMetadata2);
-        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(3), eq(EventApiClient.SortOrder.DESC))).thenReturn(Optional.of(eventResponse2));
+        when(client.getEvents(eq("feed"), isNull(), isNull(), eq(3),
+                eq(EventApiClient.SortOrder.DESC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse2));
         when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), any())).thenThrow(new RuntimeException("wrong way"));
 
         //when
@@ -206,8 +212,9 @@ class EventApiServiceTest {
         pageMetadata.setNextAfterValue(now);
         eventResponse.setPageMetadata(pageMetadata);
 
-        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
-        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.empty());
+        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.empty());
         when(client.getEvents(eq("feed"), isNull(), isNull(), eq(3), any())).thenThrow(new RuntimeException("wrong way"));
 
         //when
@@ -234,13 +241,14 @@ class EventApiServiceTest {
         eventResponse.setPageMetadata(pageMetadata);
 
         OffsetDateTime hourTrimmedDate = OffsetDateTime.now().minusDays(4).truncatedTo(ChronoUnit.HOURS);
-        when(client.getEvents(eq("feed"), argThat(date -> date.isEqual(hourTrimmedDate)), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), argThat(date -> date.isEqual(hourTrimmedDate)), isNull(), eq(3),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
 
         EventApiClient.EventApiSearchEventResponse eventResponse2 = new EventApiClient.EventApiSearchEventResponse();
         eventResponse2.setData(List.of(factory.manufacturePojo(EventApiEventDto.class)));
         EventApiClient.PageMetadata pageMetadata2 = new EventApiClient.PageMetadata();
         eventResponse2.setPageMetadata(pageMetadata2);
-        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse2));
+        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse2));
         when(client.getEvents(eq("feed"), isNull(), isNull(), eq(3), any())).thenThrow(new RuntimeException("wrong way"));
 
         //when
@@ -266,7 +274,8 @@ class EventApiServiceTest {
         pageMetadata.setNextAfterValue(now);
         eventResponse.setPageMetadata(pageMetadata);
 
-        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse));
+        when(client.getEvents(eq("feed"), any(OffsetDateTime.class), isNull(), eq(3),
+                eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse));
 
         EventApiClient.EventApiSearchEventResponse eventResponse2 = new EventApiClient.EventApiSearchEventResponse();
         EventApiEventDto event4 = factory.manufacturePojo(EventApiEventDto.class);
@@ -277,13 +286,13 @@ class EventApiServiceTest {
         OffsetDateTime now2 = OffsetDateTime.now();
         pageMetadata2.setNextAfterValue(now2);
         eventResponse2.setPageMetadata(pageMetadata2);
-        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse2));
+        when(client.getEvents(eq("feed"), eq(now), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse2));
 
         EventApiClient.EventApiSearchEventResponse eventResponse3 = new EventApiClient.EventApiSearchEventResponse();
         eventResponse3.setData(List.of(factory.manufacturePojo(EventApiEventDto.class)));
         EventApiClient.PageMetadata pageMetadata3 = new EventApiClient.PageMetadata();
         eventResponse3.setPageMetadata(pageMetadata3);
-        when(client.getEvents(eq("feed"), eq(now2), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC))).thenReturn(Optional.of(eventResponse3));
+        when(client.getEvents(eq("feed"), eq(now2), isNull(), eq(3), eq(EventApiClient.SortOrder.ASC), eq(GeometryFilterType.ALL))).thenReturn(Optional.of(eventResponse3));
         when(client.getEvents(eq("feed"), isNull(), isNull(), eq(3), any())).thenThrow(new RuntimeException("wrong way"));
 
         //when
@@ -305,11 +314,11 @@ class EventApiServiceTest {
         event.getEventDetails().put("populatedAreaKm2", "123234");
 
         UUID eventId = UUID.randomUUID();
-        when(client.getEvent(eventId, null, false)).thenReturn(event);
+        when(client.getEvent(eventId, null, false, GeometryFilterType.ALL)).thenReturn(event);
         //when
         EventDto result = service.getEvent(eventId, null);
         //then
-        verify(client, times(1)).getEvent(eventId, null, false);
+        verify(client, times(1)).getEvent(eventId, null, false, GeometryFilterType.ALL);
         //some EventDto fields
         assertEquals(event.getProperName(), result.getEventName());
         assertEquals(event.getLocation(), result.getLocation());
@@ -327,11 +336,11 @@ class EventApiServiceTest {
 
 
         UUID eventId = UUID.fromString("f4919979-3668-48f1-91af-94b3c5bffe2a");
-        when(client.getEvent(eventId, null, true)).thenReturn(event);
+        when(client.getEvent(eventId, null, true, GeometryFilterType.ALL)).thenReturn(event);
         //when
         List<EventEpisodeListDto> result = service.getEventEpisodes(eventId, null);
         //then
-        verify(client, times(1)).getEvent(eventId, null, true);
+        verify(client, times(1)).getEvent(eventId, null, true, GeometryFilterType.ALL);
         //some EventDto fields
         assertEquals(5, result.size());
         assertEquals("Thermal anomaly in United States, California, San Diego County. Burnt area 2.518 km²",


### PR DESCRIPTION
## Summary
- add `GeometryFilterType` enum
- allow querying Event API without geometry
- expose geometry filtering to Event API endpoints
- adjust client, service, controller, and tests accordingly

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6851b525209c8324bc9b59ca253202a4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for filtering events by geometry type when retrieving event lists and individual events. Users can now specify a geometry filter in relevant API requests.

- **Bug Fixes**
  - Updated tests to ensure compatibility with the new geometry filter parameter in event retrieval APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->