### PR TITLE
Add Slack digest for minor disasters

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackDigestService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackDigestService.java
@@ -1,0 +1,63 @@
+package io.kontur.disasterninja.notifications.slack;
+
+import io.kontur.disasterninja.client.EventApiClient;
+import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Component
+@ConditionalOnProperty(value = "notifications.slack.enabled")
+public class SlackDigestService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SlackDigestService.class);
+
+    private final SlackSender slackSender;
+    private final EventApiClient eventApiClient;
+
+    @Value("${notifications.feed}")
+    private String eventApiFeed;
+
+    public SlackDigestService(SlackSender slackSender,
+                              EventApiClient eventApiClient) {
+        this.slackSender = slackSender;
+        this.eventApiClient = eventApiClient;
+    }
+
+    @Scheduled(cron = "${notifications.slack.digestCron:0 0 18 * * *}")
+    public void sendDigest() {
+        OffsetDateTime startOfDay = OffsetDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+
+        Optional<EventApiClient.EventApiSearchEventResponse> critical = eventApiClient.getEvents(eventApiFeed,
+                startOfDay, null, 1, EventApiClient.SortOrder.ASC);
+        if (critical.isPresent()) {
+            return;
+        }
+
+        Optional<EventApiClient.EventApiSearchEventResponse> minorResponse =
+                eventApiClient.getEventsBySeverities(eventApiFeed, startOfDay, List.of("MINOR"), 100,
+                        EventApiClient.SortOrder.ASC);
+        if (minorResponse.isEmpty()) {
+            return;
+        }
+        List<EventApiEventDto> events = minorResponse.get().getData();
+        if (events.isEmpty()) {
+            return;
+        }
+
+        String list = events.stream()
+                .map(EventApiEventDto::getName)
+                .collect(Collectors.joining("\n• ", "• ", ""));
+        String text = String.format("{\"text\":\"Non-critical disasters today:\n%s\"}", list.replace("\"", "\\\""));
+        slackSender.send(text);
+        LOG.info("Sent Slack digest about {} non-critical disasters", events.size());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,7 @@ notifications:
   enabled: false
   slack:
     enabled: false
+    digestCron: '0 0 18 * * *'
   email:
     enabled: false
 


### PR DESCRIPTION
## Summary
- add SlackDigestService for sending daily digest of non-critical events
- allow querying Event API for specific severities
- configure default digest schedule in application.yml

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6851cb9e28288324b5be965dba70278b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced daily Slack digest notifications summarizing non-critical disasters, sent at 18:00 if enabled.
  - Added filtering of events by severity in event retrieval.

- **Chores**
  - Added configuration option to customize the Slack digest schedule via a cron expression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->