### PR TITLE
Implement population increase check for notifications

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/NotificationService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/NotificationService.java
@@ -7,16 +7,57 @@ import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class NotificationService {
 
     private static final List<String> acceptableTypes = Arrays.asList("FLOOD", "EARTHQUAKE", "CYCLONE", "VOLCANO", "WILDFIRE");
+    private static final ConcurrentHashMap<UUID, Long> lastNotifiedPopulation = new ConcurrentHashMap<>();
 
     public boolean isApplicable(EventApiEventDto event) {
         return isEventInPopulatedArea(event) && isEventTypeAppropriate(event) && isEventSeverityAppropriate(event);
     }
 
     public abstract void process(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics);
+
+    protected static boolean hasPopulationIncreasedSignificantly(EventApiEventDto event) {
+        Long currentPopulation = extractPopulation(event);
+        if (currentPopulation == null) {
+            return false;
+        }
+        Long previous = lastNotifiedPopulation.get(event.getEventId());
+        if (previous == null) {
+            return true;
+        }
+        BigDecimal threshold = new BigDecimal(previous).multiply(new BigDecimal("1.3"));
+        return new BigDecimal(currentPopulation).compareTo(threshold) > 0;
+    }
+
+    protected static void recordPopulation(EventApiEventDto event) {
+        Long currentPopulation = extractPopulation(event);
+        if (currentPopulation != null) {
+            lastNotifiedPopulation.put(event.getEventId(), currentPopulation);
+        }
+    }
+
+    private static Long extractPopulation(EventApiEventDto event) {
+        try {
+            if (event.getEpisodes() == null || event.getEpisodes().isEmpty()) {
+                return null;
+            }
+            Map<String, Object> details = event.getEpisodes().get(0).getEpisodeDetails();
+            if (details == null) {
+                return null;
+            }
+            Object value = details.get("population");
+            if (value == null) {
+                return null;
+            }
+            return new BigDecimal(String.valueOf(value)).longValue();
+        } catch (Exception e) {
+            return null;
+        }
+    }
 
     private boolean isEventInPopulatedArea(EventApiEventDto event) {
         if (event.getEpisodes().get(0).getEpisodeDetails() == null) {

--- a/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
@@ -75,6 +75,11 @@ public class NotificationsProcessor {
                     break;
                 }
 
+                if (!NotificationService.hasPopulationIncreasedSignificantly(event)) {
+                    continue;
+                }
+
+                boolean processed = false;
                 for (NotificationService notificationService : notificationServices) {
                     if (notificationService.isApplicable(event)) {
                         Geometry geometry = convertGeometry(event.getGeometries());
@@ -87,8 +92,12 @@ public class NotificationsProcessor {
                             LOG.error("Failed to obtain analytics for notification. Event ID = '{}', name = '{}'. {}", event.getEventId(), event.getName(), e.getMessage(), e);
                         }
                         notificationService.process(event, urbanPopulationProperties, analytics);
-                        latestUpdatedDate = event.getUpdatedAt();
+                        processed = true;
                     }
+                }
+                if (processed) {
+                    NotificationService.recordPopulation(event);
+                    latestUpdatedDate = event.getUpdatedAt();
                 }
             }
         } catch (RestClientException e) {

--- a/src/main/java/io/kontur/disasterninja/notifications/email/EmailNotificationService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/email/EmailNotificationService.java
@@ -83,7 +83,8 @@ public class EmailNotificationService extends NotificationService {
         return event.getEventDetails() != null
                 && event.getEpisodes() != null
                 && event.getEpisodes().stream().noneMatch(episode -> episode.getEpisodeDetails() == null)
-                && !CollectionUtils.isEmpty(getRelevantLocations(event.getGeometries()));
+                && !CollectionUtils.isEmpty(getRelevantLocations(event.getGeometries()))
+                && super.isApplicable(event);
     }
 
     private List<Partner> getPartners(List<Feature> partnerLocations) {


### PR DESCRIPTION
## Summary
- add tracking of last notified population count
- skip notifications unless population grows by 30%
- record updated population when sending
- ensure email service also applies common checks

## Testing
- `./gradlew check`

------
https://chatgpt.com/codex/tasks/task_e_6851cc57663c832496aa6580c6a3ec84