### PR TITLE
Add affected countries calculation

### DIFF
--- a/src/main/java/io/kontur/disasterninja/controller/CountriesController.java
+++ b/src/main/java/io/kontur/disasterninja/controller/CountriesController.java
@@ -1,0 +1,37 @@
+package io.kontur.disasterninja.controller;
+
+import io.kontur.disasterninja.service.CountriesService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.wololo.geojson.GeoJSON;
+
+import java.util.Set;
+
+@Tag(name = "Countries", description = "Countries API")
+@RestController
+@RequestMapping("/countries")
+@RequiredArgsConstructor
+public class CountriesController {
+
+    private final CountriesService countriesService;
+
+    @Operation(summary = "Return list of ISO3 codes of countries affected by input geometry", tags = {"Countries"},
+            description = "Returns list of ISO3 codes of countries for selected geometry using LayersApi service")
+    @ApiResponse(responseCode = "200", description = "Successful operation",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = String.class)))
+    @PostMapping
+    public Set<String> getAffectedCountries(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description =
+                    "Geometry in GeoJSON format. Send as FeatureCollection or Feature or Geometry")
+            @RequestBody GeoJSON geoJSON) {
+        return countriesService.getAffectedCountries(geoJSON);
+    }
+}

--- a/src/main/java/io/kontur/disasterninja/service/CountriesService.java
+++ b/src/main/java/io/kontur/disasterninja/service/CountriesService.java
@@ -1,0 +1,33 @@
+package io.kontur.disasterninja.service;
+
+import io.kontur.disasterninja.client.LayersApiClient;
+import io.kontur.disasterninja.domain.DtoFeatureProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.wololo.geojson.Feature;
+import org.wololo.geojson.GeoJSON;
+import org.wololo.geojson.Geometry;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CountriesService {
+
+    private static final String KONTUR_BOUNDARIES = "konturBoundaries";
+
+    private final LayersApiClient layersApiClient;
+    private final GeometryTransformer geometryTransformer;
+
+    public Set<String> getAffectedCountries(GeoJSON geoJSON) {
+        Geometry geometry = geometryTransformer.getGeometryFromGeoJson(geoJSON);
+        List<Feature> features = layersApiClient.getCollectionFeatures(geometry, KONTUR_BOUNDARIES, null);
+        return features.stream()
+                .map(f -> (String) f.getProperties().get(DtoFeatureProperties.COUNTRY_CODE))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+    }
+}

--- a/src/test/java/io/kontur/disasterninja/service/CountriesServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/CountriesServiceTest.java
@@ -1,0 +1,65 @@
+package io.kontur.disasterninja.service;
+
+import io.kontur.disasterninja.client.LayersApiClient;
+import io.kontur.disasterninja.domain.DtoFeatureProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.wololo.geojson.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CountriesServiceTest {
+
+    @Mock
+    private LayersApiClient layersApiClient;
+
+    @Mock
+    private GeometryTransformer geometryTransformer;
+
+    @InjectMocks
+    private CountriesService countriesService;
+
+    @Test
+    public void getAffectedCountriesTest() {
+        String geoJsonString = """
+                {
+                  "type":"Feature",
+                  "geometry":{"type":"Polygon","coordinates":[[[0,0],[1,0],[1,1],[0,1],[0,0]]]},
+                  "properties":{}
+                }
+                """;
+        GeoJSON geoJSON = GeoJSONFactory.create(geoJsonString);
+        Geometry geometry = ((Feature) geoJSON).getGeometry();
+
+        ArgumentCaptor<Geometry> geometryArgumentCaptor = ArgumentCaptor.forClass(Geometry.class);
+
+        Feature f1 = new Feature(new Point(new double[]{0,0}), Map.of(DtoFeatureProperties.COUNTRY_CODE, "USA"));
+        Feature f2 = new Feature(new Point(new double[]{1,1}), Map.of(DtoFeatureProperties.COUNTRY_CODE, "CAN"));
+
+        when(geometryTransformer.getGeometryFromGeoJson(any())).thenReturn(geometry);
+        when(layersApiClient.getCollectionFeatures(geometryArgumentCaptor.capture(), eq("konturBoundaries"), isNull()))
+                .thenReturn(List.of(f1, f2));
+
+        Set<String> result = countriesService.getAffectedCountries(geoJSON);
+
+        assertEquals(Set.of("USA", "CAN"), result);
+        assertEquals(geometry, geometryArgumentCaptor.getValue());
+
+        verify(geometryTransformer).getGeometryFromGeoJson(any(GeoJSON.class));
+        verify(layersApiClient).getCollectionFeatures(geometry, "konturBoundaries", null);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CountriesService` to calculate affected countries from geometry
- expose `/countries` endpoint
- cover service with unit test

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6851ce2983a48324bac1ce0589d992d2