### PR TITLE
Fix legend hexagon step shape parsing

### DIFF
--- a/src/main/java/io/kontur/disasterninja/domain/enums/LayerStepShape.java
+++ b/src/main/java/io/kontur/disasterninja/domain/enums/LayerStepShape.java
@@ -9,6 +9,7 @@ public enum LayerStepShape {
     SQUARE("square"),
     CIRCLE("circle"),
     HEX("hex"),
+    HEXAGON("hexagon"),
     ICON("icon");
 
     private final String value;

--- a/src/test/java/io/kontur/disasterninja/service/layers/LayersApiServiceTest.java
+++ b/src/test/java/io/kontur/disasterninja/service/layers/LayersApiServiceTest.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.kontur.disasterninja.client.LayersApiClient;
 import io.kontur.disasterninja.domain.Layer;
 import io.kontur.disasterninja.domain.Legend;
+import io.kontur.disasterninja.domain.enums.LayerStepShape;
 import io.kontur.disasterninja.dto.AppLayerUpdateDto;
 import io.kontur.disasterninja.dto.LayersApiApplicationDto;
 import io.kontur.disasterninja.dto.layer.LayerCreateDto;
@@ -69,6 +70,20 @@ public class LayersApiServiceTest {
         //then
         verify(layersApiClient, times(1)).getCollection(id, null);
         assertLayer(layer);
+    }
+
+    @Test
+    public void getLayerHexagonStepShapeTest() throws JsonProcessingException {
+        //given
+        when(layersApiClient.getCollection(any(), any())).thenReturn(collectionHexagon());
+
+        //when
+        Layer layer = layersApiService.getLayer(null, id, null);
+
+        //then
+        verify(layersApiClient, times(1)).getCollection(id, null);
+        assertNotNull(layer.getLegend());
+        assertEquals(LayerStepShape.HEXAGON, layer.getLegend().getSteps().get(0).getStepShape());
     }
 
     @Test
@@ -197,6 +212,24 @@ public class LayersApiServiceTest {
                 "{\"paramName\":\"param name\",\"paramValue\":\"asd\",\"axis\":null,\"axisValue\":null," +
                 "\"stepName\":\"step name2\",\"stepShape\":\"hex\",\"style\":{\"prop\":\"value\"}," +
                 "\"sourceLayer\":\"source-layer\",\"stepIconFill\":\"\",\"stepIconStroke\":\"\"}]," +
+                "\"tooltip\": {\"type\": \"markdown\",\"paramName\": \"tooltipContent\"},\"colors\": " +
+                "[{\"id\":\"A1\",\"color\":\"rgb(232,232,157)\"}],\"axes\":{\"x\":{\"label\": \"xLabel\"}," +
+                "\"y\":{\"label\": \"yLabel\"}}}", ObjectNode.class));
+
+        return collection;
+    }
+
+    private Collection collectionHexagon() throws JsonProcessingException {
+        Collection collection = new Collection();
+        collection.setId(id);
+        collection.setTitle(title);
+        collection.setLegendStyle(new ObjectMapper().readValue("{\"name\":\"legendName\",\"type\":\"simple\"," +
+                "\"linkProperty\":null,\"steps\":[{\"paramName\":\"param name\",\"paramValue\":\"qwe\",\"axis\":null," +
+                "\"axisValue\":null,\"stepName\":\"step name\",\"stepShape\":\"hexagon\",\"style\":{\"prop\":\"value\"}," +
+                "\"sourceLayer\":\"users\",\"stepIconFill\":\"fill\",\"stepIconStroke\":\"stroke\"}," +
+                "{\"paramName\":\"param name\",\"paramValue\":\"asd\",\"axis\":null,\"axisValue\":null," +
+                "\"stepName\":\"step name2\",\"stepShape\":\"hexagon\",\"style\":{\"prop\":\"value\"}," +
+                "\"sourceLayer\":\"users\",\"stepIconFill\":\"\",\"stepIconStroke\":\"\"}]," +
                 "\"tooltip\": {\"type\": \"markdown\",\"paramName\": \"tooltipContent\"},\"colors\": " +
                 "[{\"id\":\"A1\",\"color\":\"rgb(232,232,157)\"}],\"axes\":{\"x\":{\"label\": \"xLabel\"}," +
                 "\"y\":{\"label\": \"yLabel\"}}}", ObjectNode.class));


### PR DESCRIPTION
## Summary
- support `hexagon` legend step shape
- test LayersApiService handling of `hexagon` step shape

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_685d15f218fc8324a09948a1b0edf323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new "hexagon" shape option in layer step shapes.

* **Tests**
  * Introduced a new test to verify correct handling of the "hexagon" step shape in layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->