### PR TITLE
Fix Slack formatting for > characters

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -40,8 +40,15 @@ public class SlackMessageFormatter extends MessageFormatter {
         String colorCode = getMessageColorCode(event, latestEpisode, false);
         String status = getEventStatus(event);
         String alertUrl = createAlertLink(event, latestEpisode);
-        String title = colorCode + status + event.getName();
+        String title = colorCode + status + sanitizeEventName(event.getName());
         return String.format(BODY, alertUrl, title, description);
+    }
+
+    static String sanitizeEventName(String name) {
+        if (StringUtils.isBlank(name)) {
+            return name;
+        }
+        return name.replace(">=", "\u2265").replace('>', '\u2265');
     }
 
     private String convertNotificationDescription(FeedEpisode latestEpisode) {

--- a/src/test/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatterTest.java
+++ b/src/test/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatterTest.java
@@ -1,0 +1,13 @@
+package io.kontur.disasterninja.notifications.slack;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SlackMessageFormatterTest {
+
+    @Test
+    public void sanitizeEventNameReplacesProblemCharacters() {
+        String result = SlackMessageFormatter.sanitizeEventName("Event >=5 >4");
+        assertEquals("Event ≥5 ≥4", result);
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize Slack event names to replace `>` and `>=` with `≥`
- test new sanitization method

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6861a3c863e0832491df647b554d19f2