### PR TITLE
Add magnitude & category fields for events

### DIFF
--- a/src/main/java/io/kontur/disasterninja/dto/EventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventDto.java
@@ -16,6 +16,8 @@ public class EventDto {
     private String description;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private FeatureCollection geojson;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private EventType eventType;

--- a/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
@@ -14,6 +14,8 @@ public class EventEpisodeListDto {
     private String name;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
@@ -15,6 +15,8 @@ public class EventListDto {
     private String description;
     private String location;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private Long affectedPopulation;
     private Double settledArea;
     private Long osmGaps;

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
@@ -17,6 +17,8 @@ public class EventApiEventDto {
     private String description;
     private String type;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
@@ -18,6 +18,8 @@ public class FeedEpisode {
     private String location;
     private Boolean active;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
@@ -44,6 +44,8 @@ public class EventDtoConverter {
         }
         dto.setEventType(eventType);
         dto.setSeverity(event.getSeverity());
+        dto.setMagnitude(event.getMagnitude());
+        dto.setCategory(event.getCategory());
 
         if (event.getEventDetails() != null) {
             Map<String, Object> eventDetails = event.getEventDetails();
@@ -58,6 +60,12 @@ public class EventDtoConverter {
             }
             if (eventDetails.containsKey("osmGapsPercentage")) {
                 dto.setOsmGaps(convertLong(eventDetails.get("osmGapsPercentage")));
+            }
+            if (eventDetails.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(eventDetails.get("magnitude")));
+            }
+            if (eventDetails.containsKey("category")) {
+                dto.setCategory(String.valueOf(eventDetails.get("category")));
             }
         }
 
@@ -81,6 +89,21 @@ public class EventDtoConverter {
                 .updatedAt(episode.getUpdatedAt())
                 .geojson(episode.getGeometries())
                 .build();
+        Map<String, Object> details = episode.getEpisodeDetails();
+        if (details != null) {
+            if (details.containsKey("magnitude")) {
+                result.setMagnitude(convertDouble(details.get("magnitude")));
+            }
+            if (details.containsKey("category")) {
+                result.setCategory(String.valueOf(details.get("category")));
+            }
+        }
+        if (result.getMagnitude() == null) {
+            result.setMagnitude(episode.getMagnitude());
+        }
+        if (result.getCategory() == null) {
+            result.setCategory(episode.getCategory());
+        }
         return result;
     }
 

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
@@ -22,6 +22,8 @@ public class EventListEventDtoConverter {
         dto.setExternalUrls(eventUrls != null ? List.copyOf(eventUrls) : List.of());
 
         dto.setSeverity(event.getSeverity());
+        dto.setMagnitude(event.getMagnitude());
+        dto.setCategory(event.getCategory());
         Map<String, Object> eventDetails = event.getEventDetails();
         if (eventDetails != null) {
             if (eventDetails.containsKey("population")) {
@@ -35,6 +37,12 @@ public class EventListEventDtoConverter {
             }
             if (eventDetails.containsKey("loss")) {
                 dto.setLoss(convertLong(event.getEventDetails().get("loss")));
+            }
+            if (eventDetails.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(eventDetails.get("magnitude")));
+            }
+            if (eventDetails.containsKey("category")) {
+                dto.setCategory(String.valueOf(eventDetails.get("category")));
             }
         }
         dto.setUpdatedAt(event.getUpdatedAt());


### PR DESCRIPTION
https://kontur.fibery.io/Tasks/Task/dn-be-Add-magnitude-category-to-disaster-16914

## Summary
- extend DTOs with `magnitude` and `category`
- include new fields when converting Event API data

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68627e274c0c832fa527bd8178ba9468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying event magnitude and category information across event and episode details.

* **Bug Fixes**
  * Improved consistency in how event magnitude and category data are populated and displayed from various sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->