### PR TITLE
Add magnitude and category support

### DIFF
--- a/src/main/java/io/kontur/disasterninja/dto/EventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventDto.java
@@ -16,6 +16,8 @@ public class EventDto {
     private String description;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private FeatureCollection geojson;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private EventType eventType;

--- a/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
@@ -14,6 +14,8 @@ public class EventEpisodeListDto {
     private String name;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
@@ -15,6 +15,8 @@ public class EventListDto {
     private String description;
     private String location;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private Long affectedPopulation;
     private Double settledArea;
     private Long osmGaps;

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
@@ -17,6 +17,8 @@ public class EventApiEventDto {
     private String description;
     private String type;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
@@ -18,6 +18,8 @@ public class FeedEpisode {
     private String location;
     private Boolean active;
     private Severity severity;
+    private Double magnitude;
+    private String category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
@@ -44,6 +44,8 @@ public class EventDtoConverter {
         }
         dto.setEventType(eventType);
         dto.setSeverity(event.getSeverity());
+        dto.setMagnitude(event.getMagnitude());
+        dto.setCategory(event.getCategory());
 
         if (event.getEventDetails() != null) {
             Map<String, Object> eventDetails = event.getEventDetails();
@@ -58,6 +60,12 @@ public class EventDtoConverter {
             }
             if (eventDetails.containsKey("osmGapsPercentage")) {
                 dto.setOsmGaps(convertLong(eventDetails.get("osmGapsPercentage")));
+            }
+            if (eventDetails.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(eventDetails.get("magnitude")));
+            }
+            if (eventDetails.containsKey("category")) {
+                dto.setCategory(String.valueOf(eventDetails.get("category")));
             }
         }
 
@@ -75,12 +83,29 @@ public class EventDtoConverter {
                 .name(episode.getName())
                 .externalUrls(episode.getUrls())
                 .severity(episode.getSeverity())
+                .magnitude(episode.getMagnitude())
+                .category(episode.getCategory())
                 .location(episode.getLocation())
                 .startedAt(episode.getStartedAt())
                 .endedAt(episode.getEndedAt())
                 .updatedAt(episode.getUpdatedAt())
                 .geojson(episode.getGeometries())
                 .build();
+        Map<String, Object> details = episode.getEpisodeDetails();
+        if (details != null) {
+            if (details.containsKey("magnitude")) {
+                result.setMagnitude(convertDouble(details.get("magnitude")));
+            }
+            if (details.containsKey("category")) {
+                result.setCategory(String.valueOf(details.get("category")));
+            }
+        }
+        if (result.getMagnitude() == null) {
+            result.setMagnitude(episode.getMagnitude());
+        }
+        if (result.getCategory() == null) {
+            result.setCategory(episode.getCategory());
+        }
         return result;
     }
 

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
@@ -22,6 +22,8 @@ public class EventListEventDtoConverter {
         dto.setExternalUrls(eventUrls != null ? List.copyOf(eventUrls) : List.of());
 
         dto.setSeverity(event.getSeverity());
+        dto.setMagnitude(event.getMagnitude());
+        dto.setCategory(event.getCategory());
         Map<String, Object> eventDetails = event.getEventDetails();
         if (eventDetails != null) {
             if (eventDetails.containsKey("population")) {
@@ -35,6 +37,12 @@ public class EventListEventDtoConverter {
             }
             if (eventDetails.containsKey("loss")) {
                 dto.setLoss(convertLong(event.getEventDetails().get("loss")));
+            }
+            if (eventDetails.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(eventDetails.get("magnitude")));
+            }
+            if (eventDetails.containsKey("category")) {
+                dto.setCategory(String.valueOf(eventDetails.get("category")));
             }
         }
         dto.setUpdatedAt(event.getUpdatedAt());


### PR DESCRIPTION
## Summary
- add magnitude and category fields to Event DTOs
- propagate new fields from Event API objects to our output

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6862a8b63cc0832f8306cd5a554f6c85