### PR TITLE
Add magnitude and category fields

### DIFF
--- a/src/main/java/io/kontur/disasterninja/dto/EventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventDto.java
@@ -16,6 +16,8 @@ public class EventDto {
     private String description;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private Integer category;
     private FeatureCollection geojson;
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private EventType eventType;

--- a/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventEpisodeListDto.java
@@ -14,6 +14,8 @@ public class EventEpisodeListDto {
     private String name;
     private List<String> externalUrls;
     private Severity severity;
+    private Double magnitude;
+    private Integer category;
     private OffsetDateTime startedAt;
     private OffsetDateTime endedAt;
     private OffsetDateTime updatedAt;

--- a/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/EventListDto.java
@@ -15,6 +15,8 @@ public class EventListDto {
     private String description;
     private String location;
     private Severity severity;
+    private Double magnitude;
+    private Integer category;
     private Long affectedPopulation;
     private Double settledArea;
     private Long osmGaps;

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/EventApiEventDto.java
@@ -23,6 +23,7 @@ public class EventApiEventDto {
     private FeatureCollection geometries;
     private List<FeedEpisode> episodes = new ArrayList<>();
     private Map<String, Object> eventDetails = new HashMap<>();
+    private Map<String, Object> severityData = new HashMap<>();
     private List<String> urls;
     private String location;
     private List<Double> bbox = new ArrayList<>();

--- a/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
+++ b/src/main/java/io/kontur/disasterninja/dto/eventapi/FeedEpisode.java
@@ -24,6 +24,7 @@ public class FeedEpisode {
     private OffsetDateTime sourceUpdatedAt;
     private Set<UUID> observations = new HashSet<>();
     private Map<String, Object> episodeDetails;
+    private Map<String, Object> severityData = new HashMap<>();
     private FeatureCollection geometries;
     private List<String> urls;
 }

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventDtoConverter.java
@@ -45,6 +45,16 @@ public class EventDtoConverter {
         dto.setEventType(eventType);
         dto.setSeverity(event.getSeverity());
 
+        if (event.getSeverityData() != null) {
+            Map<String, Object> severityData = event.getSeverityData();
+            if (severityData.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(severityData.get("magnitude")));
+            }
+            if (severityData.containsKey("categorySaffirSimpson")) {
+                dto.setCategory(convertInteger(severityData.get("categorySaffirSimpson")));
+            }
+        }
+
         if (event.getEventDetails() != null) {
             Map<String, Object> eventDetails = event.getEventDetails();
             if (eventDetails.containsKey("populatedAreaKm2")) {
@@ -75,6 +85,12 @@ public class EventDtoConverter {
                 .name(episode.getName())
                 .externalUrls(episode.getUrls())
                 .severity(episode.getSeverity())
+                .magnitude(episode.getSeverityData() != null && episode.getSeverityData().containsKey("magnitude")
+                        ? convertDouble(episode.getSeverityData().get("magnitude"))
+                        : null)
+                .category(episode.getSeverityData() != null && episode.getSeverityData().containsKey("categorySaffirSimpson")
+                        ? convertInteger(episode.getSeverityData().get("categorySaffirSimpson"))
+                        : null)
                 .location(episode.getLocation())
                 .startedAt(episode.getStartedAt())
                 .endedAt(episode.getEndedAt())

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
@@ -22,6 +22,15 @@ public class EventListEventDtoConverter {
         dto.setExternalUrls(eventUrls != null ? List.copyOf(eventUrls) : List.of());
 
         dto.setSeverity(event.getSeverity());
+        if (event.getSeverityData() != null) {
+            Map<String, Object> severityData = event.getSeverityData();
+            if (severityData.containsKey("magnitude")) {
+                dto.setMagnitude(convertDouble(severityData.get("magnitude")));
+            }
+            if (severityData.containsKey("categorySaffirSimpson")) {
+                dto.setCategory(convertInteger(severityData.get("categorySaffirSimpson")));
+            }
+        }
         Map<String, Object> eventDetails = event.getEventDetails();
         if (eventDetails != null) {
             if (eventDetails.containsKey("population")) {
@@ -59,6 +68,14 @@ public class EventListEventDtoConverter {
             return 0L;
         } else {
             return Double.parseDouble(String.valueOf(value));
+        }
+    }
+
+    protected static Integer convertInteger(Object value) {
+        if (value == null || "null".equals(String.valueOf(value))) {
+            return 0;
+        } else {
+            return (int) Math.round(Double.parseDouble(String.valueOf(value)));
         }
     }
 

--- a/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
+++ b/src/main/java/io/kontur/disasterninja/service/converter/EventListEventDtoConverter.java
@@ -63,9 +63,9 @@ public class EventListEventDtoConverter {
         }
     }
 
-    protected static double convertDouble(Object value) {
+    protected static Double convertDouble(Object value) {
         if (value == null || "null".equals(String.valueOf(value))) {
-            return 0L;
+            return 0d;
         } else {
             return Double.parseDouble(String.valueOf(value));
         }

--- a/src/test/java/io/kontur/disasterninja/domain/EventApiConvertersTest.java
+++ b/src/test/java/io/kontur/disasterninja/domain/EventApiConvertersTest.java
@@ -159,6 +159,42 @@ public class EventApiConvertersTest {
     }
 
     @Test
+    public void eventDtoSeverityDataEdgeCasesTest() {
+        EventApiEventDto event = testEvent();
+
+        EventDto dto = EventDtoConverter.convert(event);
+        assertNull(dto.getMagnitude());
+        assertNull(dto.getCategory());
+
+        FeedEpisode episode = event.getEpisodes().get(0);
+        EventEpisodeListDto episodeDto = EventDtoConverter.convertEventEpisode(episode);
+        assertNull(episodeDto.getMagnitude());
+        assertNull(episodeDto.getCategory());
+
+        event.setSeverityData(new HashMap<>());
+        dto = EventDtoConverter.convert(event);
+        assertNull(dto.getMagnitude());
+        assertNull(dto.getCategory());
+
+        episode.setSeverityData(new HashMap<>());
+        episodeDto = EventDtoConverter.convertEventEpisode(episode);
+        assertNull(episodeDto.getMagnitude());
+        assertNull(episodeDto.getCategory());
+
+        event.getSeverityData().put("magnitude", null);
+        event.getSeverityData().put("categorySaffirSimpson", null);
+        dto = EventDtoConverter.convert(event);
+        assertEquals(0.0, dto.getMagnitude());
+        assertEquals(0, dto.getCategory());
+
+        episode.getSeverityData().put("magnitude", null);
+        episode.getSeverityData().put("categorySaffirSimpson", null);
+        episodeDto = EventDtoConverter.convertEventEpisode(episode);
+        assertEquals(0.0, episodeDto.getMagnitude());
+        assertEquals(0, episodeDto.getCategory());
+    }
+
+    @Test
     public void eventListDtoTestNulls() {
         EventApiEventDto event = testEvent();
         EventListDto dto = EventListEventDtoConverter.convert(event);

--- a/src/test/java/io/kontur/disasterninja/domain/EventApiConvertersTest.java
+++ b/src/test/java/io/kontur/disasterninja/domain/EventApiConvertersTest.java
@@ -4,6 +4,7 @@ import io.kontur.disasterninja.dto.EventDto;
 import io.kontur.disasterninja.dto.EventListDto;
 import io.kontur.disasterninja.dto.EventType;
 import io.kontur.disasterninja.dto.Severity;
+import io.kontur.disasterninja.dto.EventEpisodeListDto;
 import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
 import io.kontur.disasterninja.dto.eventapi.FeedEpisode;
 import io.kontur.disasterninja.service.converter.EventDtoConverter;
@@ -134,6 +135,27 @@ public class EventApiConvertersTest {
         event.setEpisodeCount(2);
         dto = EventDtoConverter.convert(event);
         assertEquals(dto.getEpisodeCount(), 2);
+    }
+
+    @Test
+    public void eventDtoSeverityDataTest() {
+        EventApiEventDto event = testEvent();
+        event.setSeverityData(new HashMap<>());
+        event.getSeverityData().put("magnitude", 5.6);
+        event.getSeverityData().put("categorySaffirSimpson", 3);
+
+        EventDto dto = EventDtoConverter.convert(event);
+        assertEquals(5.6, dto.getMagnitude());
+        assertEquals(3, dto.getCategory());
+
+        FeedEpisode episode = event.getEpisodes().get(0);
+        episode.setSeverityData(new HashMap<>());
+        episode.getSeverityData().put("magnitude", 4.5);
+        episode.getSeverityData().put("categorySaffirSimpson", 2);
+
+        EventEpisodeListDto episodeDto = EventDtoConverter.convertEventEpisode(episode);
+        assertEquals(4.5, episodeDto.getMagnitude());
+        assertEquals(2, episodeDto.getCategory());
     }
 
     @Test


### PR DESCRIPTION
## Summary
- include `severityData` in event and episode DTOs
- surface `magnitude` and `category` in event and episode models
- convert new values from Event API responses
- cover severity data with tests

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686b8b1b9670832fae2f01ecc769aaa6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "magnitude" and "category" fields to event-related data, providing more detailed event information.
  * Severity details are now extracted and displayed where available.

* **Tests**
  * Introduced new tests to verify correct conversion and handling of the new severity data fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->