### PR TITLE
Fix optional email notifications

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
@@ -84,7 +84,7 @@ public class NotificationsProcessor {
     @Scheduled(fixedRate = 60000, initialDelay = 1000)
     public void run() {
         processFeed(eventApiFeed);
-        if (eventApiFeed2 != null && !"none".equalsIgnoreCase(eventApiFeed2)) {
+        if (eventApiFeed2 != null && !"".equalsIgnoreCase(eventApiFeed2) && !"none".equalsIgnoreCase(eventApiFeed2)) {
             processFeed(eventApiFeed2);
         }
     }


### PR DESCRIPTION
## Summary
- allow NotificationsProcessor to start when email notifications are disabled

## Testing
- `./gradlew test --no-daemon` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_686f9f3996cc832abc72afcca9cfccaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of notifications by ensuring the app handles the absence of email notification service gracefully, preventing potential errors when email functionality is not configured.
  * Enhanced validation to skip processing of invalid or disabled notification feeds, reducing unnecessary operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->