### PR TITLE
Adjust feed2 notifications

### DIFF
--- a/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/NotificationsProcessor.java
@@ -9,6 +9,7 @@ import io.kontur.disasterninja.notifications.email.EmailNotificationService;
 import io.kontur.disasterninja.notifications.slack.SlackMessageFormatter;
 import io.kontur.disasterninja.notifications.slack.SlackSender;
 import io.kontur.disasterninja.notifications.slack.SlackNotificationService;
+import io.kontur.disasterninja.notifications.slack.SlackNotificationServiceFeed2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,8 +159,8 @@ public class NotificationsProcessor {
         }
 
         if (feed.equals(eventApiFeed2)) {
-            // customize formatter or request parameters here for the second slack receiver if needed
-            result.add(new SlackNotificationService(slackMessageFormatter, slackSender, eventApiFeed2, slackWebHook2));
+            // second Slack receiver sends all events without filters and without links
+            result.add(new SlackNotificationServiceFeed2(slackMessageFormatter, slackSender, eventApiFeed2, slackWebHook2));
         }
 
         return result;

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -28,11 +28,19 @@ public class SlackMessageFormatter extends MessageFormatter {
 
     public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
                          Map<String, Double> analytics, boolean includeLink) {
+        return format(event, urbanPopulationProperties, analytics, includeLink, false);
+    }
+
+    public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
+                         Map<String, Double> analytics, boolean includeLink, boolean includeEventId) {
         FeedEpisode latestEpisode = getLatestEpisode(event);
         Map<String, Object> episodeDetails = latestEpisode.getEpisodeDetails();
         Map<String, Object> eventDetails = event.getEventDetails();
 
         StringBuilder description = new StringBuilder();
+        if (includeEventId) {
+            description.append("\n>event_id: ").append(event.getEventId());
+        }
         description.append(convertNotificationDescription(latestEpisode));
         description.append(convertUrbanStatistic(urbanPopulationProperties));
         description.append(convertPopulationStatistic(episodeDetails));

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -15,6 +15,7 @@ import static io.kontur.disasterninja.util.FormatUtil.formatNumber;
 public class SlackMessageFormatter extends MessageFormatter {
 
     private static final String BODY = "{\"text\":\"><%s|%s>%s\", \"unfurl_links\":true, \"unfurl_media\": true}";
+    private static final String BODY_WITHOUT_LINK = "{\"text\":\"%s%s\", \"unfurl_links\":true, \"unfurl_media\": true}";
     private static final String gdacsReportLinkPattern = "https://www.gdacs.org/report.aspx?eventtype=%s&eventid=%s";
 
     @Value("${notifications.alertUrlPattern:}")
@@ -22,6 +23,11 @@ public class SlackMessageFormatter extends MessageFormatter {
 
     public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
                          Map<String, Double> analytics) {
+        return format(event, urbanPopulationProperties, analytics, true);
+    }
+
+    public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
+                         Map<String, Double> analytics, boolean includeLink) {
         FeedEpisode latestEpisode = getLatestEpisode(event);
         Map<String, Object> episodeDetails = latestEpisode.getEpisodeDetails();
         Map<String, Object> eventDetails = event.getEventDetails();
@@ -39,7 +45,10 @@ public class SlackMessageFormatter extends MessageFormatter {
         String status = getEventStatus(event);
         String alertUrl = createAlertLink(event, latestEpisode);
         String title = colorCode + status + sanitizeEventName(event.getName());
-        return String.format(BODY, alertUrl, title, description);
+        if (includeLink) {
+            return String.format(BODY, alertUrl, title, description);
+        }
+        return String.format(BODY_WITHOUT_LINK, title, description);
     }
 
     static String sanitizeEventName(String name) {

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -72,6 +72,16 @@ public class SlackMessageFormatter extends MessageFormatter {
         return String.format(SIMPLE_BODY, text);
     }
 
+    public String getColorCode(EventApiEventDto event, boolean unicode) {
+        FeedEpisode latest = getLatestEpisode(event);
+        return getMessageColorCode(event, latest, unicode);
+    }
+
+    String toPlain(String text) {
+        String noQuotes = text.replaceAll("(?m)^>\\s*", "");
+        return noQuotes.replaceAll(":[^\\s:]+:\\s*", "");
+    }
+
     static String sanitizeEventName(String name) {
         if (StringUtils.isBlank(name)) {
             return name;

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -77,9 +77,8 @@ public class SlackMessageFormatter extends MessageFormatter {
         return getMessageColorCode(event, latest, unicode);
     }
 
-    String toPlain(String text) {
-        String noQuotes = text.replaceAll("(?m)^>\\s*", "");
-        return noQuotes.replaceAll(":[^\\s:]+:\\s*", "");
+    String removeEmoji(String text) {
+        return text.replaceAll(":[^:]+?:", "");
     }
 
     static String sanitizeEventName(String name) {

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -29,20 +29,14 @@ public class SlackMessageFormatter extends MessageFormatter {
 
     public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
                          Map<String, Double> analytics, boolean includeLink) {
-        return format(event, urbanPopulationProperties, analytics, includeLink, false, true);
+        return format(event, urbanPopulationProperties, analytics, includeLink, true);
     }
 
     public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
                          Map<String, Double> analytics, boolean includeLink,
-                         boolean includeEventId) {
-        return format(event, urbanPopulationProperties, analytics, includeLink, includeEventId, true);
-    }
-
-    public String format(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
-                         Map<String, Double> analytics, boolean includeLink,
-                         boolean includeEventId, boolean includeEmoji) {
+                         boolean includeEmoji) {
         FeedEpisode latestEpisode = getLatestEpisode(event);
-        String description = buildDescription(event, urbanPopulationProperties, analytics, includeEventId, includeEmoji);
+        String description = buildDescription(event, urbanPopulationProperties, analytics, includeEmoji);
 
         String colorCode = getMessageColorCode(event, latestEpisode, false);
         String status = getEventStatus(event);
@@ -55,16 +49,12 @@ public class SlackMessageFormatter extends MessageFormatter {
     }
 
     public String buildDescription(EventApiEventDto event, Map<String, Object> urbanPopulationProperties,
-                                   Map<String, Double> analytics, boolean includeEventId,
-                                   boolean includeEmoji) {
+                                   Map<String, Double> analytics, boolean includeEmoji) {
         FeedEpisode latestEpisode = getLatestEpisode(event);
         Map<String, Object> episodeDetails = latestEpisode.getEpisodeDetails();
         Map<String, Object> eventDetails = event.getEventDetails();
 
         StringBuilder description = new StringBuilder();
-        if (includeEventId) {
-            description.append("\n>event_id: ").append(event.getEventId());
-        }
         description.append(convertNotificationDescription(latestEpisode));
         description.append(convertUrbanStatistic(urbanPopulationProperties, includeEmoji));
         description.append(convertPopulationStatistic(episodeDetails, includeEmoji));
@@ -83,10 +73,6 @@ public class SlackMessageFormatter extends MessageFormatter {
     public String getColorCode(EventApiEventDto event, boolean unicode) {
         FeedEpisode latest = getLatestEpisode(event);
         return getMessageColorCode(event, latest, unicode);
-    }
-
-    String removeEmoji(String text) {
-        return text.replaceAll(":[^:]+?:", "");
     }
 
     static String sanitizeEventName(String name) {

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackMessageFormatter.java
@@ -75,6 +75,14 @@ public class SlackMessageFormatter extends MessageFormatter {
         return getMessageColorCode(event, latest, unicode);
     }
 
+    /**
+     * Expose event status so other services can reuse the same logic for
+     * determining whether the event is an update or a new one.
+     */
+    public String getStatus(EventApiEventDto event) {
+        return getEventStatus(event);
+    }
+
     static String sanitizeEventName(String name) {
         if (StringUtils.isBlank(name)) {
             return name;

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationService.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationService.java
@@ -11,7 +11,7 @@ public class SlackNotificationService extends NotificationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(SlackNotificationService.class);
 
-    private final SlackMessageFormatter slackMessageFormatter;
+    protected final SlackMessageFormatter slackMessageFormatter;
     private final SlackSender slackSender;
     private final String eventApiFeed;
     private final String slackWebHookUrl;
@@ -31,13 +31,17 @@ public class SlackNotificationService extends NotificationService {
         LOG.info("Found new event, sending slack notification. Event ID = '{}', name = '{}'", event.getEventId(), event.getName());
 
         try {
-            String message = slackMessageFormatter.format(event, urbanPopulationProperties, analytics);
+            String message = formatMessage(event, urbanPopulationProperties, analytics);
             // customize formatter if needed for a specific Slack receiver
             slackSender.send(message, slackWebHookUrl);
             LOG.info("Successfully sent slack notification from feed {}. Event ID = '{}', name = '{}'", eventApiFeed, event.getEventId(), event.getName());
         } catch (Exception e) {
             LOG.error("Failed to process slack notification. Event ID = '{}', name = '{}'. {}", event.getEventId(), event.getName(), e.getMessage(), e);
         }
+    }
+
+    protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
+        return slackMessageFormatter.format(event, urbanPopulationProperties, analytics);
     }
 
     @Override

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -28,14 +28,18 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         String header = buildHeader(event);
         String eventIdLine = "event_id: " + event.getEventId();
 
-        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
-        description = slackMessageFormatter.removeEmoji(description);
+        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics,
+                false, false);
 
-        String color = slackMessageFormatter.getColorCode(event, true);
         if (description.startsWith("\n")) {
             description = description.substring(1);
         }
-        description = color + description;
+        String color = slackMessageFormatter.getColorCode(event, true);
+        if (description.startsWith(">")) {
+            description = "> " + color + description.substring(1);
+        } else {
+            description = color + description;
+        }
 
         String text = header + "\n" + eventIdLine + "\n" + description;
         return slackMessageFormatter.wrapPlain(text);

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -1,14 +1,21 @@
 package io.kontur.disasterninja.notifications.slack;
 
 import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.text.WordUtils;
 
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
+
+import static java.time.ZoneOffset.UTC;
 
 /**
  * Slack notification service for feed2 that ignores applicability checks and
  * omits event links in the message.
  */
 public class SlackNotificationServiceFeed2 extends SlackNotificationService {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm 'UTC'");
 
     public SlackNotificationServiceFeed2(SlackMessageFormatter slackMessageFormatter,
                                          SlackSender slackSender,
@@ -19,7 +26,45 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
 
     @Override
     protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
-        return slackMessageFormatter.format(event, urbanPopulationProperties, analytics, false, true);
+        StringBuilder header = new StringBuilder();
+        header.append("Event Type: ")
+              .append(WordUtils.capitalizeFully(String.valueOf(event.getType())))
+              .append("\n");
+
+        String category = extractCategory(event);
+        if (StringUtils.isNotBlank(category)) {
+            header.append("Category: ").append(category).append("\n");
+        }
+
+        if (StringUtils.isNotBlank(event.getLocation())) {
+            header.append("Location: ").append(event.getLocation()).append("\n");
+        }
+
+        if (event.getStartedAt() != null) {
+            header.append("Event Time Date: ")
+                  .append(event.getStartedAt().withOffsetSameInstant(UTC).format(DATE_FORMATTER))
+                  .append("\n");
+        }
+
+        header.append("Update Status: ")
+              .append(event.getVersion() == 1 ? "New" : "Update")
+              .append("\n");
+        header.append("event_id: ").append(event.getEventId());
+
+        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
+        String text = header.append(description).toString();
+        return slackMessageFormatter.wrapPlain(text);
+    }
+
+    private String extractCategory(EventApiEventDto event) {
+        if (event.getSeverityData() == null) {
+            return "";
+        }
+        Object value = event.getSeverityData().get("severitytext");
+        if (value == null) {
+            value = event.getSeverityData().get("severityText");
+        }
+        return value != null ? String.valueOf(value) : "";
     }
 
     @Override

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -19,7 +19,7 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
 
     @Override
     protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
-        return slackMessageFormatter.format(event, urbanPopulationProperties, analytics, false);
+        return slackMessageFormatter.format(event, urbanPopulationProperties, analytics, false, true);
     }
 
     @Override

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -28,20 +28,16 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         String header = buildHeader(event);
         String eventIdLine = "event_id: " + event.getEventId();
 
-        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics,
-                false, false);
+        String color = slackMessageFormatter.getColorCode(event, true);
+        String status = event.getVersion() == 1 ? "" : "[Update] ";
+        String firstLine = "> " + color + status + SlackMessageFormatter.sanitizeEventName(event.getName());
 
+        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
         if (description.startsWith("\n")) {
             description = description.substring(1);
         }
-        String color = slackMessageFormatter.getColorCode(event, true);
-        if (description.startsWith(">")) {
-            description = "> " + color + description.substring(1);
-        } else {
-            description = color + description;
-        }
 
-        String text = header + "\n" + eventIdLine + "\n" + description;
+        String text = header + "\n" + eventIdLine + "\n" + firstLine + "\n" + description;
         return slackMessageFormatter.wrapPlain(text);
     }
 

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -1,0 +1,31 @@
+package io.kontur.disasterninja.notifications.slack;
+
+import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
+
+import java.util.Map;
+
+/**
+ * Slack notification service for feed2 that ignores applicability checks and
+ * omits event links in the message.
+ */
+public class SlackNotificationServiceFeed2 extends SlackNotificationService {
+
+    public SlackNotificationServiceFeed2(SlackMessageFormatter slackMessageFormatter,
+                                         SlackSender slackSender,
+                                         String eventApiFeed,
+                                         String slackWebHookUrl) {
+        super(slackMessageFormatter, slackSender, eventApiFeed, slackWebHookUrl);
+    }
+
+    @Override
+    protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
+        return slackMessageFormatter.format(event, urbanPopulationProperties, analytics, false);
+    }
+
+    @Override
+    public boolean isApplicable(EventApiEventDto event) {
+        return true;
+    }
+
+    // use inherited getEventApiFeed()
+}

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -26,8 +26,18 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
     @Override
     protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
         String header = buildHeader(event);
-        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, true);
-        String text = header + description;
+        String eventIdLine = "event_id: " + event.getEventId();
+
+        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
+        description = slackMessageFormatter.toPlain(description);
+
+        String color = slackMessageFormatter.getColorCode(event, true);
+        if (description.startsWith("\n")) {
+            description = description.substring(1);
+        }
+        description = color + description;
+
+        String text = header + "\n" + eventIdLine + "\n" + description;
         return slackMessageFormatter.wrapPlain(text);
     }
 

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -29,7 +29,7 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         String eventIdLine = "event_id: " + event.getEventId();
 
         String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
-        description = slackMessageFormatter.toPlain(description);
+        description = slackMessageFormatter.removeEmoji(description);
 
         String color = slackMessageFormatter.getColorCode(event, true);
         if (description.startsWith("\n")) {
@@ -47,10 +47,7 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
               .append(StringUtils.capitalize(String.valueOf(event.getType()).toLowerCase()))
               .append("\n");
 
-        String category = extractCategory(event);
-        if (StringUtils.isNotBlank(category)) {
-            header.append("Category: ").append(category).append("\n");
-        }
+        // TODO: get severityData and add Category line
 
         if (StringUtils.isNotBlank(event.getLocation())) {
             header.append("Location: ").append(event.getLocation()).append("\n");
@@ -66,17 +63,6 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
               .append(event.getVersion() == 1 ? "New" : "Update");
 
         return header.toString();
-    }
-
-    private String extractCategory(EventApiEventDto event) {
-        if (event.getSeverityData() == null) {
-            return "";
-        }
-        Object value = event.getSeverityData().get("severitytext");
-        if (value == null) {
-            value = event.getSeverityData().get("severityText");
-        }
-        return value != null ? String.valueOf(value) : "";
     }
 
     @Override

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -8,10 +8,6 @@ import java.util.Map;
 
 import static java.time.ZoneOffset.UTC;
 
-/**
- * Slack notification service for feed2 that ignores applicability checks and
- * omits event links in the message.
- */
 public class SlackNotificationServiceFeed2 extends SlackNotificationService {
 
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm 'UTC'");
@@ -30,14 +26,9 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
 
         String color = slackMessageFormatter.getColorCode(event, true);
         String status = slackMessageFormatter.getStatus(event);
-        String firstLine = "> " + color + status + SlackMessageFormatter.sanitizeEventName(event.getName());
-
+        String title = "> " + color + status + SlackMessageFormatter.sanitizeEventName(event.getName());
         String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
-        if (description.startsWith("\n")) {
-            description = description.substring(1);
-        }
-
-        String text = header + "\n" + eventIdLine + "\n" + firstLine + "\n" + description;
+        String text = header + "\n" + eventIdLine + "\n" + title + description;
         return slackMessageFormatter.wrapPlain(text);
     }
 

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -2,7 +2,6 @@ package io.kontur.disasterninja.notifications.slack;
 
 import io.kontur.disasterninja.dto.eventapi.EventApiEventDto;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.text.WordUtils;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Map;
@@ -26,9 +25,16 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
 
     @Override
     protected String formatMessage(EventApiEventDto event, Map<String, Object> urbanPopulationProperties, Map<String, Double> analytics) {
+        String header = buildHeader(event);
+        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, true);
+        String text = header + description;
+        return slackMessageFormatter.wrapPlain(text);
+    }
+
+    private String buildHeader(EventApiEventDto event) {
         StringBuilder header = new StringBuilder();
         header.append("Event Type: ")
-              .append(WordUtils.capitalizeFully(String.valueOf(event.getType())))
+              .append(StringUtils.capitalize(String.valueOf(event.getType()).toLowerCase()))
               .append("\n");
 
         String category = extractCategory(event);
@@ -41,19 +47,15 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         }
 
         if (event.getStartedAt() != null) {
-            header.append("Event Time Date: ")
+            header.append("Event Time: ")
                   .append(event.getStartedAt().withOffsetSameInstant(UTC).format(DATE_FORMATTER))
                   .append("\n");
         }
 
         header.append("Update Status: ")
-              .append(event.getVersion() == 1 ? "New" : "Update")
-              .append("\n");
-        header.append("event_id: ").append(event.getEventId());
+              .append(event.getVersion() == 1 ? "New" : "Update");
 
-        String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);
-        String text = header.append(description).toString();
-        return slackMessageFormatter.wrapPlain(text);
+        return header.toString();
     }
 
     private String extractCategory(EventApiEventDto event) {
@@ -72,5 +74,4 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         return true;
     }
 
-    // use inherited getEventApiFeed()
 }

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -54,12 +54,12 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         }
 
         if (event.getStartedAt() != null) {
-            header.append("Event Time: ")
+            header.append("Event Start Date: ")
                   .append(event.getStartedAt().withOffsetSameInstant(UTC).format(DATE_FORMATTER))
                   .append("\n");
         }
 
-        header.append("Update Status: ")
+        header.append("Status: ")
               .append(event.getVersion() == 1 ? "New" : "Update");
 
         return header.toString();

--- a/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
+++ b/src/main/java/io/kontur/disasterninja/notifications/slack/SlackNotificationServiceFeed2.java
@@ -29,7 +29,7 @@ public class SlackNotificationServiceFeed2 extends SlackNotificationService {
         String eventIdLine = "event_id: " + event.getEventId();
 
         String color = slackMessageFormatter.getColorCode(event, true);
-        String status = event.getVersion() == 1 ? "" : "[Update] ";
+        String status = slackMessageFormatter.getStatus(event);
         String firstLine = "> " + color + status + SlackMessageFormatter.sanitizeEventName(event.getName());
 
         String description = slackMessageFormatter.buildDescription(event, urbanPopulationProperties, analytics, false);


### PR DESCRIPTION
## Summary
- add ability to format Slack messages without a link
- new Slack service for feed2 ignoring event filters and omitting links
- use the custom service in `NotificationsProcessor`
- refactor feed2 Slack service to extend the base service

## Testing
- `./gradlew test --no-daemon`
- `./gradlew assemble --no-daemon`


------
https://chatgpt.com/codex/tasks/task_b_68710e0cc6a0832aba75a8507b0f19b5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Slack notifications for the second feed now send all events without filters and exclude event links.
* **Refactor**
  * Enhanced Slack message formatting with options to include or exclude event links and emojis.
  * Added flexibility to customize Slack message formatting in notification services through a new extension point.
  * Introduced a new Slack notification service variant with simplified message formatting and unconditional event applicability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->